### PR TITLE
publish: fix publish, add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,17 @@ $ kubectl logs crossplane-examples-hello-world-65d5c59976-vzppd | grep 'Hello Wo
 That's it! We've finished writing, building, and locally validating a
 stack!
 
-## Bonus: How to build for external publishing
+
+### Remove the stack
+
+When we're done with the stack and want to remove it and all its
+resources, we can `uninstall` it by name:
+
+```
+kubectl crossplane stack uninstall 'crossplane-examples-hello-world'
+```
+
+## How to build for external publishing
 After we finish developing a stack locally, we may want to publish it to
 an external registry. This section shows the commands to do that.
 
@@ -246,6 +256,9 @@ Once the stack is built, we can use the `publish` subcommand to publish
 it to the registry:
 
 ```
+# You may need to log into dockerhub or the docker registry that the
+# image is being pushed to. If that's the case, run:
+# $ docker login
 kubectl crossplane stack publish
 ```
 
@@ -257,6 +270,18 @@ the `install` command:
 ```
 kubectl crossplane stack install 'crossplane-examples/hello-world'
 ```
+
+### Uninstall
+Installing the stack can be done with some sample yaml which was
+generated for us by the `init` that we ran earlier, but it's a
+little easier to use the `uninstall` command:
+
+```
+kubectl crossplane stack uninstall 'crossplane-examples-hello-world'
+```
+
+Note that `uninstall` uses the stack's name (which has no `/` characters),
+while the `install` uses the image name (which uses `/`).
 
 
 [kubebuilder quick start]: https://book.kubebuilder.io/quick-start.html

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -143,7 +143,7 @@ EOF
 
   cat > stack.env <<EOF
 # Image URL to use all building/pushing image targets
-IMG ?= ${STACK_NAME}:latest
+STACK_IMG ?= ${STACK_NAME}:latest
 
 CRD_DIR=config/crd/bases
 # Files matching this glob will be placed into the stack's
@@ -174,21 +174,7 @@ STACK_PACKAGE=stack-package
 STACK_PACKAGE_REGISTRY=$(STACK_PACKAGE)/.registry
 
 all: build
-
-################################################
-#
-# Below this until marked otherwise is where
-# most of the build customizations beyond
-# what kubebuilder generates live.
-#
-# Here are some other customizations of note:
-# - Set IMG above to be more specific
-# - Add GO111MODULE=on
-# - Add COPY of stack bundle in Dockerfile
-# - Add some other make variables
-# - Made docker-build recipe work well on MacOS
-#
-################################################
+.PHONY: all
 
 clean: clean-stack-package clean-binary
 .PHONY: clean
@@ -202,6 +188,10 @@ clean-binary:
 .PHONY: clean-binary
 
 build: bundle docker-build
+.PHONY: build
+
+publish: docker-push
+.PHONY: publish
 
 # Initialize the stack bundle folder
 $(STACK_PACKAGE_REGISTRY):
@@ -239,13 +229,13 @@ docker-local-registry:
 # Tagging the image with the address of the local registry is a necessary step of
 # publishing the image to the local registry.
 docker-local-tag: docker-local-registry
-	docker tag ${IMG} localhost:5000/${IMG}
+	docker tag ${STACK_IMG} localhost:5000/${STACK_IMG}
 .PHONY: docker-local-tag
 
 # When we are developing locally, this target will publish our container image
 # to the local registry.
 docker-local-push: docker-local-tag docker-local-registry
-	docker push localhost:5000/${IMG}
+	docker push localhost:5000/${STACK_IMG}
 .PHONY: docker-local-push
 
 # Sooo ideally this wouldn't be a single line, but the idea here is that when we're
@@ -291,16 +281,18 @@ stack-uninstall:
 
 # Build the docker image
 docker-build: bundle
-	docker build --file stack.Dockerfile . -t ${IMG}
+	docker build --file stack.Dockerfile . -t ${STACK_IMG}
 	@echo "updating kustomize image patch file for manager resource"
 	@# The argument to sed -i and the subsequent rm make the in-place sed work well on MacOS.
 	@# There is no good way to do an in-place replacement with sed without leaving behind a
 	@# temporary file.
-	sed -i '.bak' -e 's@image: .*@image: '"${IMG}"'@' ./config/default/manager_image_patch.yaml
+	sed -i '.bak' -e 's@image: .*@image: '"${STACK_IMG}"'@' ./config/default/manager_image_patch.yaml
 	rm ./config/default/manager_image_patch.yaml.bak
+.PHONY: docker-build
 
 docker-push:
-	docker push ${IMG}
+	docker push ${STACK_IMG}
+.PHONY: docker-push
 EOF
   echo 'Created stack.Makefile' >&2
 

--- a/bin/kubectl-crossplane-stack-publish
+++ b/bin/kubectl-crossplane-stack-publish
@@ -1,6 +1,32 @@
 #!/usr/bin/env bash
 
 set -e
+
+function usage {
+  echo "Usage: kubectl crossplane stack publish [STACK_IMAGE_NAME]" >&2
+  echo "" >&2
+  echo "STACK_IMAGE_NAME is the name of the stack in the local docker image" >&2
+  echo "registry to publish. It will be passed to docker, so it can start with" >&2
+  echo "a local registry address to publish to a local registry. If unspecified," >&2
+  echo "it will use whatever name the project was initialized with." >&2
+  echo "" >&2
+  echo "Examples:" >&2
+  echo "" >&2
+  echo "Publish a stack using the default image name:" >&2
+  echo "kubectl crossplane stack publish" >&2
+  echo "" >&2
+  echo "Publish a stack to a local registry:" >&2
+  echo "kubectl crossplane stack publish localhost:5000/mystackname" >&2
+}
+
+# STACK_IMG is used by the build to specify the image name to use.
+# If we override it, it changes which image name is used for any
+# build, tag, or publish steps.
+if [[ $# -gt 0 ]]; then
+  STACK_IMG="${1}"
+  export STACK_IMG
+fi
+
 set -x
 
 make -f stack.Makefile publish


### PR DESCRIPTION
Related to crossplaneio/crossplane#711

## Overview

Previously, the `publish` operation was not well-tested, even by hand.
This changeset adds some documentation and fixes based on trying it out.
It also makes it a bit easier to use; the image name can now be
overridden by passing an argument.

## Testing done

Tested locally by publishing a local image (with an overridden name) and publishing an image (with an overridden name) to a private dockerhub repository.

## Notes for reviewers

This is intended more as an FYI than as a merge which will be blocked on a review, but feel free to leave comments. If the changeset is already merged, I'll revisit the commented areas in the future!