### PR TITLE
install: add bootstrap script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,18 @@
 
 ## Installation
 
-Get the commands on the PATH so `kubectl` can pick them up:
+Here's the one-liner to do it:
+
 ```
-curl -o /usr/local/bin/kubectl-crossplane-stack-build https://raw.githubusercontent.com/crossplaneio/crossplane-cli/master/bin/kubectl-crossplane-stack-build -s >/dev/null
-curl -o /usr/local/bin/kubectl-crossplane-stack-init https://raw.githubusercontent.com/crossplaneio/crossplane-cli/master/bin/kubectl-crossplane-stack-init -s >/dev/null
-curl -o /usr/local/bin/kubectl-crossplane-stack-publish https://raw.githubusercontent.com/crossplaneio/crossplane-cli/master/bin/kubectl-crossplane-stack-publish -s >/dev/null
-curl -o /usr/local/bin/kubectl-crossplane-stack-install https://raw.githubusercontent.com/crossplaneio/crossplane-cli/master/bin/kubectl-crossplane-stack-install -s >/dev/null
-curl -o /usr/local/bin/kubectl-crossplane-stack-uninstall https://raw.githubusercontent.com/crossplaneio/crossplane-cli/master/bin/kubectl-crossplane-stack-uninstall -s >/dev/null
-curl -o /usr/local/bin/kubectl-crossplane-stack-generate_install https://raw.githubusercontent.com/crossplaneio/crossplane-cli/master/bin/kubectl-crossplane-stack-generate_install -s >/dev/null
-chmod +x /usr/local/bin/kubectl-crossplane-stack-*
+RELEASE=master
+curl -s https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | bash
+```
+
+The behavior is customizable via environment variables:
+
+```
+RELEASE=9760f8a7fd4fdd7f9a6cf3d5323a605412a65d11
+curl -s https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | env PREFIX=${HOME} RELEASE=${RELEASE} bash
 ```
 
 ### Installing from source
@@ -28,6 +31,13 @@ everything with:
 
 ```
 rm /usr/local/bin/kubectl-crossplane-stack-*
+```
+
+Or, if you customized the installation prefix:
+
+```
+PREFIX=/thing
+rm "${PREFIX}"/bin/kubectl-crossplane-stack-*
 ```
 
 ### Uninstalling from source
@@ -101,13 +111,8 @@ Copy the plugins to somewhere on your `PATH`. If you have
 `/usr/local/bin` on your `PATH`, you can do it like this:
 
 ```
-curl -o /usr/local/bin/kubectl-crossplane-stack-build https://raw.githubusercontent.com/crossplaneio/crossplane-cli/master/bin/kubectl-crossplane-stack-build -s >/dev/null
-curl -o /usr/local/bin/kubectl-crossplane-stack-init https://raw.githubusercontent.com/crossplaneio/crossplane-cli/master/bin/kubectl-crossplane-stack-init -s >/dev/null
-curl -o /usr/local/bin/kubectl-crossplane-stack-publish https://raw.githubusercontent.com/crossplaneio/crossplane-cli/master/bin/kubectl-crossplane-stack-publish -s >/dev/null
-curl -o /usr/local/bin/kubectl-crossplane-stack-install https://raw.githubusercontent.com/crossplaneio/crossplane-cli/master/bin/kubectl-crossplane-stack-install -s >/dev/null
-curl -o /usr/local/bin/kubectl-crossplane-stack-uninstall https://raw.githubusercontent.com/crossplaneio/crossplane-cli/master/bin/kubectl-crossplane-stack-uninstall -s >/dev/null
-curl -o /usr/local/bin/kubectl-crossplane-stack-generate_install https://raw.githubusercontent.com/crossplaneio/crossplane-cli/master/bin/kubectl-crossplane-stack-generate_install -s >/dev/null
-chmod +x /usr/local/bin/kubectl-crossplane-stack-*
+RELEASE=master
+curl -s https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | bash
 ```
 
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ -z "${PREFIX}" ]]; then
+  PREFIX=/usr/local
+fi
+
+if [[ -z "${RELEASE}" ]]; then
+  RELEASE=master
+fi
+
+set -x
+
+curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-build https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-build >/dev/null
+curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-init https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-init >/dev/null
+curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-publish https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-publish >/dev/null
+curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-install https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-install >/dev/null
+curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-uninstall https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-uninstall >/dev/null
+curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-generate_install https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-generate_install >/dev/null
+chmod +x "${PREFIX}"/bin/kubectl-crossplane-stack-*


### PR DESCRIPTION
Related to crossplaneio/crossplane#740

## Overview

Even though the installation process was very copy-pasteable, it was
getting a bit intimidating since it was already seven lines long. This
changeset adds the same commands inside a bash script so that the
installation can be done in a single one-liner instead.

## Testing done

Tested locally with and without customization, using `cat` instead of `curl`:

```
cat bootstrap.sh | env PREFIX=$HOME RELEASE=9760f8a7fd4fdd7f9a6cf3d5323a605412a65d11 bash
```

## Notes for reviewers

This is more of an FYI than a changeset which will block on a review, but feel free to leave comments! If the code is already merged, I'll revisit the comments in the future.