### PR TITLE
commands: add list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ kubectl crossplane stack init 'myname/mysubname'
 kubectl crossplane stack build
 kubectl crossplane stack publish
 kubectl crossplane stack install 'myname/mysubname'
+kubectl crossplane stack list
 kubectl crossplane stack uninstall 'myname-mysubname'
 ```
 

--- a/bin/kubectl-crossplane-stack-list
+++ b/bin/kubectl-crossplane-stack-list
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+function usage {
+  # The reason for putting stack name before stack image source is it seems like stack name
+  # would be overridden more often than stack image source, but I kept going back and
+  # forth on that originally. Overriding the source is very useful when developing a
+  # stack locally, for example.
+  echo "Usage: kubectl crossplane stack list [OPTIONS]" >&2
+  echo "" >&2
+  echo "Lists installed stacks. If any OPTIONS are provided, they will be passed" >&2
+  echo "through to kubectl." >&2
+  echo "" >&2
+  echo "If no OPTIONS are provided, stacks in all namespaces will be listed." >&2
+}
+
+if [[ "${1}" == "help" ]] ; then
+  usage
+  exit 1
+fi
+
+ALL_NAMESPACES='--all-namespaces'
+
+if [[ $# -gt 0 ]]; then
+  ALL_NAMESPACES=
+fi
+
+kubectl get stackrequests.stacks.crossplane.io ${ALL_NAMESPACES} "${@}"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -18,4 +18,5 @@ curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-publish https://raw.githubus
 curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-install https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-install >/dev/null
 curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-uninstall https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-uninstall >/dev/null
 curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-generate_install https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-generate_install >/dev/null
+curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-list https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-list >/dev/null
 chmod +x "${PREFIX}"/bin/kubectl-crossplane-stack-*


### PR DESCRIPTION
## Overview

When interacting with the wordpress stack, it seemed useful to be able
to list all installed stacks, so this changeset adds a `list` command
which does that. The default behavior is to list stacks in all
namespaces. If any arguments are passed, it'll use those instead (and
pass them through to `kubectl`)

## Testing done

Tested these commands locally:

```
kubectl crossplane stack list
kubectl crossplane stack list -n default
kubectl crossplane stack list crossplane-examples-hello-world -o yaml
kubectl crossplane stack list crossplane-examples-hello-world -o yaml -n dawefoijwaef
```

## Notes for reviewers

This is more of an FYI than a merge that will block on reviewing, but feel free to add comments! If the code is already merged, I'll revisit them in the future.