### PR TITLE
Add help support

### DIFF
--- a/bin/kubectl-crossplane-stack-build
+++ b/bin/kubectl-crossplane-stack-build
@@ -1,6 +1,25 @@
 #!/usr/bin/env bash
 
+function usage {
+  echo "Usage: kubectl crossplane stack build [ARGS ...]" >&2
+  echo "" >&2
+  echo "ARGS: An alternate recipe to build, or other arguments to pass through" >&2
+  echo 'to `make`.' >&2
+}
 
+function check_help {
+  if [ "${1}" == "-h" -o "${1}" == "--help" ] ; then
+    usage
+    exit 1
+  fi
+}
+
+check_help "${1}"
+
+# We could also have just passed all the arguments through
+# instead of extracting the command out, but it seems more
+# clear what is happening in the no-argument case if the
+# command is split out.
 COMMAND=${1:-build}
 shift
 

--- a/bin/kubectl-crossplane-stack-build
+++ b/bin/kubectl-crossplane-stack-build
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
 function usage {
-  echo "Usage: kubectl crossplane stack build [ARGS ...]" >&2
+  echo "Usage: kubectl crossplane stack [-h|--help] build [ARGS ...]" >&2
   echo "" >&2
   echo "ARGS: An alternate recipe to build, or other arguments to pass through" >&2
   echo 'to `make`.' >&2
+  echo "" >&2
+  echo "-h, --help: Print usage" >&2
 }
 
 function check_help {

--- a/bin/kubectl-crossplane-stack-generate_install
+++ b/bin/kubectl-crossplane-stack-generate_install
@@ -7,11 +7,13 @@ function usage {
   # would be overridden more often than stack image source, but I kept going back and
   # forth on that originally. Overriding the source is very useful when developing a
   # stack locally, for example.
-  echo "Usage: kubectl crossplane stack generate-install STACK_IMAGE_NAME [STACK_NAME [STACK_IMAGE_SOURCE]]" >&2
+  echo "Usage: kubectl crossplane stack generate-install [-h|--help] STACK_IMAGE_NAME [STACK_NAME [STACK_IMAGE_SOURCE]]" >&2
   echo "" >&2
   echo "STACK_IMAGE_NAME is the name of the stack in the registry to install." >&2
   echo "If the STACK_NAME is not provided, the stack name will be the STACK_IMAGE_NAME with any '/' characters" >&2
   echo "converted to '-' characters." >&2
+  echo "" >&2
+  echo "-h, --help: Print usage" >&2
 }
 
 function check_help {

--- a/bin/kubectl-crossplane-stack-generate_install
+++ b/bin/kubectl-crossplane-stack-generate_install
@@ -14,6 +14,15 @@ function usage {
   echo "converted to '-' characters." >&2
 }
 
+function check_help {
+  if [ "${1}" == "-h" -o "${1}" == "--help" ] ; then
+    usage
+    exit 1
+  fi
+}
+
+check_help "${1}"
+
 if [[ $# -lt 1 ]] ; then
   usage
   exit 1

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -3,7 +3,7 @@
 set -e
 
 function usage {
-  echo "Usage: kubectl crossplane stack init [-f|--force] STACK_NAME [DIRECTORY]" >&2
+  echo "Usage: kubectl crossplane stack init [-h|--help] [-f|--force] STACK_NAME [DIRECTORY]" >&2
   echo "" >&2
   echo "STACK_NAME is used as the image name for the stack, and any '/' characters" >&2
   echo "are converted to '-' characters when populating kubernetes resource field names." >&2
@@ -11,6 +11,7 @@ function usage {
   echo "DIRECTORY defaults to the current directory." >&2
   echo "" >&2
   echo "-f, --force: force init when a previous 'stack init' is detected" >&2
+  echo "-h, --help: Print usage" >&2
 }
 
 function check_help {

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -13,6 +13,15 @@ function usage {
   echo "-f, --force: force init when a previous 'stack init' is detected" >&2
 }
 
+function check_help {
+  if [ "${1}" == "-h" -o "${1}" == "--help" ] ; then
+    usage
+    exit 1
+  fi
+}
+
+check_help "${1}"
+
 if [[ $# -lt 1 ]] ; then
   usage
   exit 1

--- a/bin/kubectl-crossplane-stack-install
+++ b/bin/kubectl-crossplane-stack-install
@@ -7,11 +7,13 @@ function usage {
   # would be overridden more often than stack image source, but I kept going back and
   # forth on that originally. Overriding the source is very useful when developing a
   # stack locally, for example.
-  echo "Usage: kubectl crossplane stack install STACK_IMAGE_NAME [STACK_NAME [STACK_IMAGE_SOURCE]]" >&2
+  echo "Usage: kubectl crossplane stack install [-h|--help] STACK_IMAGE_NAME [STACK_NAME [STACK_IMAGE_SOURCE]]" >&2
   echo "" >&2
   echo "STACK_IMAGE_NAME is the name of the stack in the registry to install." >&2
   echo "If the STACK_NAME is not provided, the stack name will be the STACK_IMAGE_NAME with any '/' characters" >&2
   echo "converted to '-' characters." >&2
+  echo "" >&2
+  echo "-h, --help: Print usage" >&2
   echo "" >&2
   echo 'For more advanced usage, see the lower-level `kubectl crossplane stack generate-install` command.' >&2
 }

--- a/bin/kubectl-crossplane-stack-install
+++ b/bin/kubectl-crossplane-stack-install
@@ -16,6 +16,15 @@ function usage {
   echo 'For more advanced usage, see the lower-level `kubectl crossplane stack generate-install` command.' >&2
 }
 
+function check_help {
+  if [ "${1}" == "-h" -o "${1}" == "--help" ] ; then
+    usage
+    exit 1
+  fi
+}
+
+check_help "${1}"
+
 if [[ $# -lt 1 ]] ; then
   usage
   exit 1

--- a/bin/kubectl-crossplane-stack-list
+++ b/bin/kubectl-crossplane-stack-list
@@ -7,12 +7,14 @@ function usage {
   # would be overridden more often than stack image source, but I kept going back and
   # forth on that originally. Overriding the source is very useful when developing a
   # stack locally, for example.
-  echo "Usage: kubectl crossplane stack list [OPTIONS]" >&2
+  echo "Usage: kubectl crossplane stack list [-h|--help] [OPTIONS]" >&2
   echo "" >&2
   echo "Lists installed stacks. If any OPTIONS are provided, they will be passed" >&2
   echo "through to kubectl." >&2
   echo "" >&2
   echo "If no OPTIONS are provided, stacks in all namespaces will be listed." >&2
+  echo "" >&2
+  echo "-h, --help: Print usage" >&2
 }
 
 function check_help {

--- a/bin/kubectl-crossplane-stack-list
+++ b/bin/kubectl-crossplane-stack-list
@@ -15,10 +15,14 @@ function usage {
   echo "If no OPTIONS are provided, stacks in all namespaces will be listed." >&2
 }
 
-if [[ "${1}" == "help" ]] ; then
-  usage
-  exit 1
-fi
+function check_help {
+  if [ "${1}" == "-h" -o "${1}" == "--help" ] ; then
+    usage
+    exit 1
+  fi
+}
+
+check_help "${1}"
 
 ALL_NAMESPACES='--all-namespaces'
 

--- a/bin/kubectl-crossplane-stack-publish
+++ b/bin/kubectl-crossplane-stack-publish
@@ -16,8 +16,17 @@ function usage {
   echo "kubectl crossplane stack publish" >&2
   echo "" >&2
   echo "Publish a stack to a local registry:" >&2
-  echo "kubectl crossplane stack publish localhost:5000/mystackname" >&2
+  echo "kubectl crossplane stack publish localhost:5000/mystackrepository/mystackimagename" >&2
 }
+
+function check_help {
+  if [ "${1}" == "-h" -o "${1}" == "--help" ] ; then
+    usage
+    exit 1
+  fi
+}
+
+check_help "${1}"
 
 # STACK_IMG is used by the build to specify the image name to use.
 # If we override it, it changes which image name is used for any

--- a/bin/kubectl-crossplane-stack-publish
+++ b/bin/kubectl-crossplane-stack-publish
@@ -3,7 +3,7 @@
 set -e
 
 function usage {
-  echo "Usage: kubectl crossplane stack publish [STACK_IMAGE_NAME]" >&2
+  echo "Usage: kubectl crossplane stack publish [-h|--help] [STACK_IMAGE_NAME]" >&2
   echo "" >&2
   echo "STACK_IMAGE_NAME is the name of the stack in the local docker image" >&2
   echo "registry to publish. It will be passed to docker, so it can start with" >&2
@@ -17,6 +17,8 @@ function usage {
   echo "" >&2
   echo "Publish a stack to a local registry:" >&2
   echo "kubectl crossplane stack publish localhost:5000/mystackrepository/mystackimagename" >&2
+  echo "" >&2
+  echo "-h, --help: Print usage" >&2
 }
 
 function check_help {

--- a/bin/kubectl-crossplane-stack-uninstall
+++ b/bin/kubectl-crossplane-stack-uninstall
@@ -3,10 +3,12 @@
 set -e
 
 function usage {
-  echo "Usage: kubectl crossplane stack uninstall STACK_NAME [options ...]" >&2
+  echo "Usage: kubectl crossplane stack uninstall [-h|--help] STACK_NAME [options ...]" >&2
   echo "" >&2
   echo "STACK_NAME is the name of the stack to uninstall." >&2
   echo 'Namespace can also be passed, using the same syntax as a `kubectl delete` command.' >&2
+  echo "" >&2
+  echo "-h, --help: Print usage" >&2
 }
 
 function check_help {

--- a/bin/kubectl-crossplane-stack-uninstall
+++ b/bin/kubectl-crossplane-stack-uninstall
@@ -9,6 +9,15 @@ function usage {
   echo 'Namespace can also be passed, using the same syntax as a `kubectl delete` command.' >&2
 }
 
+function check_help {
+  if [ "${1}" == "-h" -o "${1}" == "--help" ] ; then
+    usage
+    exit 1
+  fi
+}
+
+check_help "${1}"
+
 if [[ $# -lt 1 ]] ; then
   usage
   exit 1


### PR DESCRIPTION
Related to crossplaneio/crossplane#735

## Overview

As part of polishing up the cli for an initial release, we want to have all of them respond to the standard `-h` and `--help` arguments. This changeset adds that.

## Testing done

Tried `-h`, `--help`, and no arguments with the `build` subcommand locally.

## Notes for reviewers

This is more of an FYI than a changeset which will block merging on getting a review. However, feel free to leave comments! If the changeset is already merged, I'll revisit them in a future change.