### PR TITLE
test: add sanity test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,12 @@ install:
 uninstall:
 	rm $(INSTALL_DIR)/kubectl-crossplane-stack-*
 .PHONY: uninstall
+
+integration-test:
+	mkdir -p test
+	# The local bin is first in the PATH so that it will still be used,
+	# even if there is anything installed elsewhere on the path
+	PATH=$(abspath bin):$(PATH) $(abspath .)/scripts/integration-test.sh \
+			 $(abspath test)
+	rm -r test
+.PHONY: integration-test

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Sanity test for the CLI. Not meant to be extremely robust
+#
+# Makes a bunch of assumptions about local setup:
+# * Prereqs installed
+# * Crossplane up and running and accessible via kubectl
+
+set -e
+set -x
+
+TEST_DIR="${1}"
+
+cd "${TEST_DIR}"
+
+GO111MODULE=on kubebuilder init --domain helloworld.stacks.crossplane.io
+yes | GO111MODULE=on kubebuilder create api --group samples --version v1alpha1 --kind HelloWorld
+
+kubectl crossplane stack init 'crossplane-examples/hello-world'
+
+sed -i .bak -e 's/\/\/ your logic here/r.Log.V(0).Info("Hello World!", "instance", req.NamespacedName)/' controllers/helloworld_controller.go
+rm -f controllers/helloworld_controller.go.bak
+
+GO111MODULE=on make manager manifests
+kubectl crossplane stack build local-build
+kubectl crossplane stack install 'crossplane-examples/hello-world' 'crossplane-examples-hello-world' localhost:5000
+
+done=true
+for i in $( seq 1 10 ); do
+  echo "Attempt ${i} to create resource . . ." >&2
+  kubectl apply -f config/samples/*.yaml || done=false
+
+  if [[ "${done}" == false ]]; then
+    echo "Create failed. Waiting before retry. . ." >&2
+    sleep 2
+    continue
+  else
+    echo "Create SUCCESS" >&2
+    break
+  fi
+done
+
+if [[ "${done}" == false ]]; then
+  echo "Error: Couldn't create resource after retries!" >&2
+  exit 1
+fi
+
+pod_name="$( kubectl get pods -A | grep hello-world | grep -v Completed | awk '{ print $2 }' )"
+kubectl logs "${pod_name}" | grep 'Hello World'


### PR DESCRIPTION
## Overview

I got tired of running the test steps by hand, so this changeset adds a
script to do it instead. The steps are roughly equivalent to the "hello
world" described in the quick start.

## Testing done

`make integration-test` locally

## Notes for reviewers

This is more of an FYI than a changeset which will block merging on review. Feel free to leave comments, and if the code is already merged, I'll take a look as part of a future effort!