### PR TITLE
update the cli for crossplane v0.3 stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Crossplane:
 kubectl crossplane stack install 'crossplane-examples/hello-world' 'crossplane-examples-hello-world' localhost:5000
 ```
 
-This can also be done using the sample local stack request that the
+This can also be done using the sample local stack install that the
 `init` command generates, but it's a good habit to use the `install`
 command.
 

--- a/bin/kubectl-crossplane-stack-generate_install
+++ b/bin/kubectl-crossplane-stack-generate_install
@@ -7,13 +7,14 @@ function usage {
   # would be overridden more often than stack image source, but I kept going back and
   # forth on that originally. Overriding the source is very useful when developing a
   # stack locally, for example.
-  echo "Usage: kubectl crossplane stack generate-install [-h|--help] STACK_IMAGE_NAME [STACK_NAME [STACK_IMAGE_SOURCE]]" >&2
+  echo "Usage: kubectl crossplane stack generate-install [-h|--help] [-c|--cluster] STACK_IMAGE_NAME [STACK_NAME [STACK_IMAGE_SOURCE]]" >&2
   echo "" >&2
   echo "STACK_IMAGE_NAME is the name of the stack in the registry to install." >&2
   echo "If the STACK_NAME is not provided, the stack name will be the STACK_IMAGE_NAME with any '/' characters" >&2
   echo "converted to '-' characters." >&2
   echo "" >&2
   echo "-h, --help: Print usage" >&2
+  echo "-c, --cluster: generate a ClusterStackInstall for Stacks with Cluster permission scope" >&2
 }
 
 function check_help {
@@ -28,6 +29,14 @@ check_help "${1}"
 if [[ $# -lt 1 ]] ; then
   usage
   exit 1
+fi
+
+CLUSTER_OPT="${1}"
+if [ "${CLUSTER_OPT}" == "-c" -o "${CLUSTER_OPT}" == "--cluster" ]; then
+  CLUSTER_STACK="Cluster"
+  shift
+else
+  CLUSTER_STACK=""
 fi
 
 STACK_IMAGE_NAME="${1}"
@@ -54,7 +63,7 @@ fi
 
 INSTALL_YAML="$( cat <<EOF
 apiVersion: stacks.crossplane.io/v1alpha1
-kind: StackRequest
+kind: ${CLUSTER_STACK}StackInstall
 metadata:
   name: "${STACK_NAME}"
 spec:

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -3,7 +3,7 @@
 set -e
 
 function usage {
-  echo "Usage: kubectl crossplane stack init [-h|--help] [-f|--force] STACK_NAME [DIRECTORY]" >&2
+  echo "Usage: kubectl crossplane stack init [-h|--help] [-f|--force] [-c|--cluster] STACK_NAME [DIRECTORY]" >&2
   echo "" >&2
   echo "STACK_NAME is used as the image name for the stack, and any '/' characters" >&2
   echo "are converted to '-' characters when populating kubernetes resource field names." >&2
@@ -11,6 +11,7 @@ function usage {
   echo "DIRECTORY defaults to the current directory." >&2
   echo "" >&2
   echo "-f, --force: force init when a previous 'stack init' is detected" >&2
+  echo "-c, --cluster: use the Cluster Stack permission scope and generate ClusterStackInstall examples" >&2
   echo "-h, --help: Print usage" >&2
 }
 
@@ -35,6 +36,16 @@ else
   FORCE_INIT=""
 fi
 
+CLUSTER_OPT=${1}
+if [ "${CLUSTER_OPT}" == "-c" -o "${CLUSTER_OPT}" == "--cluster" ]; then
+  CLUSTER_STACK="Cluster"
+  STACK_SCOPE="Cluster"
+  shift
+else
+  CLUSTER_STACK=""
+  STACK_SCOPE="Namespaced"
+fi
+
 STACK_NAME=${1}
 # For kubernetes fields, we aren't able to use slashes, and
 # slashes are common for docker image names. So we remove the
@@ -52,7 +63,25 @@ function create_dirs {
 function create_manifest {
   mkdir -p config/stack/manifests
   touch config/stack/manifests/app.yaml
-  cat > config/stack/manifests/app.yaml <<'EOF'
+  cat > config/stack/manifests/app.yaml <<EOF
+title: ""
+description: ""
+version: 0.0.1
+maintainers:
+- name: ""
+  email: ""
+owners:
+- name: ""
+  email: ""
+company: ""
+category: ""
+keywords:
+ - "crossplane-cli"
+website: ""
+source: ""
+permissionScope: ${STACK_SCOPE}
+# License SPDX name: https://spdx.org/licenses/
+license: Apache-2.0
 EOF
 
   echo 'Created config/stack/manifests/app.yaml' >&2
@@ -97,7 +126,7 @@ function create_samples {
   cat > config/stack/samples/local.install.stack.yaml <<EOF
 ---
 apiVersion: stacks.crossplane.io/v1alpha1
-kind: StackRequest
+kind: ${CLUSTER_STACK}StackInstall
 metadata:
   name: "${KUBEY_STACK_NAME}"
 spec:
@@ -109,7 +138,7 @@ EOF
   cat > config/stack/samples/install.stack.yaml <<EOF
 ---
 apiVersion: stacks.crossplane.io/v1alpha1
-kind: StackRequest
+kind: ${CLUSTER_STACK}StackInstall
 metadata:
   name: "${KUBEY_STACK_NAME}"
 spec:
@@ -172,10 +201,6 @@ EOF
 STACK_IMG ?= ${STACK_NAME}:latest
 
 CRD_DIR ?= config/crd/bases
-# Files matching this glob will be placed into the stack's
-# rbac.yaml. It could be multiple filenames or multiple
-# glob patterns.
-RBAC_GLOB ?= config/rbac/role.yaml
 STACK_PACKAGE_REGISTRY_SOURCE ?= config/stack/manifests
 LOCAL_OVERRIDES_DIR ?= config/stack/overrides
 CONFIG_SAMPLES_DIR ?= config/stack/samples
@@ -222,7 +247,7 @@ publish: docker-push
 # Initialize the stack bundle folder
 $(STACK_PACKAGE_REGISTRY):
 	mkdir -p $(STACK_PACKAGE_REGISTRY)/resources
-	touch $(STACK_PACKAGE_REGISTRY)/app.yaml $(STACK_PACKAGE_REGISTRY)/install.yaml $(STACK_PACKAGE_REGISTRY)/rbac.yaml
+	touch $(STACK_PACKAGE_REGISTRY)/app.yaml $(STACK_PACKAGE_REGISTRY)/install.yaml
 
 bundle: $(STACK_PACKAGE_REGISTRY)
 	# Copy CRDs over
@@ -238,9 +263,6 @@ bundle: $(STACK_PACKAGE_REGISTRY)
 		$(STACK_PACKAGE_REGISTRY)/resources/$$( basename $${filename/.yaml/.crd.yaml} ) \
 		; done
 
-	# If RBAC_GLOB is set *and* there is an rbac.yaml in the registry
-	# source folder, the registry source will win.
-	cat $(RBAC_GLOB) > $(STACK_PACKAGE_REGISTRY)/rbac.yaml
 	cp -r $(STACK_PACKAGE_REGISTRY_SOURCE)/* $(STACK_PACKAGE_REGISTRY)
 .PHONY: bundle
 

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -65,7 +65,9 @@ function create_manifest {
   touch config/stack/manifests/app.yaml
   cat > config/stack/manifests/app.yaml <<EOF
 title: ""
-description: ""
+readme: ""
+overview: ""
+overviewShort: ""
 version: 0.0.1
 maintainers:
 - name: ""

--- a/bin/kubectl-crossplane-stack-install
+++ b/bin/kubectl-crossplane-stack-install
@@ -51,7 +51,7 @@ KUBEY_STACK_IMAGE_NAME=$( echo "${STACK_IMAGE_NAME}" | tr '/' '-' )
 # by passing arguments
 STACK_NAME="${2:-${KUBEY_STACK_IMAGE_NAME}}"
 
-kubectl crossplane stack generate-install "${CLUSTER_OPT}" "$@" | kubectl apply -f -
+kubectl crossplane stack generate-install ${CLUSTER_OPT} "$@" | kubectl apply -f -
 # Printing out the stack install object from the cluster may be useful
 # for whoever ran this command, and there's no other output anyway, so
 # we might as well.

--- a/bin/kubectl-crossplane-stack-install
+++ b/bin/kubectl-crossplane-stack-install
@@ -7,13 +7,14 @@ function usage {
   # would be overridden more often than stack image source, but I kept going back and
   # forth on that originally. Overriding the source is very useful when developing a
   # stack locally, for example.
-  echo "Usage: kubectl crossplane stack install [-h|--help] STACK_IMAGE_NAME [STACK_NAME [STACK_IMAGE_SOURCE]]" >&2
+  echo "Usage: kubectl crossplane stack install [-h|--help] [-c|--cluster] STACK_IMAGE_NAME [STACK_NAME [STACK_IMAGE_SOURCE]]" >&2
   echo "" >&2
   echo "STACK_IMAGE_NAME is the name of the stack in the registry to install." >&2
   echo "If the STACK_NAME is not provided, the stack name will be the STACK_IMAGE_NAME with any '/' characters" >&2
   echo "converted to '-' characters." >&2
   echo "" >&2
   echo "-h, --help: Print usage" >&2
+  echo "-c, --cluster: Uninstall a Cluster scoped stack" >&2
   echo "" >&2
   echo 'For more advanced usage, see the lower-level `kubectl crossplane stack generate-install` command.' >&2
 }
@@ -32,6 +33,15 @@ if [[ $# -lt 1 ]] ; then
   exit 1
 fi
 
+CLUSTER_OPT=${1}
+if [ "${CLUSTER_OPT}" == "-c" -o "${CLUSTER_OPT}" == "--cluster" ]; then
+  CLUSTER_STACK="cluster"
+  shift
+else
+  CLUSTER_OPT=""
+  CLUSTER_STACK=""
+fi
+
 STACK_IMAGE_NAME="${1}"
 # For kubernetes fields, we aren't able to use slashes, and
 # slashes are common for docker image names. So we remove the
@@ -41,8 +51,8 @@ KUBEY_STACK_IMAGE_NAME=$( echo "${STACK_IMAGE_NAME}" | tr '/' '-' )
 # by passing arguments
 STACK_NAME="${2:-${KUBEY_STACK_IMAGE_NAME}}"
 
-kubectl crossplane stack generate-install "$@" | kubectl apply -f -
-# Printing out the stack request object from the cluster may be useful
+kubectl crossplane stack generate-install "${CLUSTER_OPT}" "$@" | kubectl apply -f -
+# Printing out the stack install object from the cluster may be useful
 # for whoever ran this command, and there's no other output anyway, so
 # we might as well.
-kubectl get -o yaml stackrequest "${STACK_NAME}"
+kubectl get -o yaml "${CLUSTER_STACK}"stackinstall "${STACK_NAME}"

--- a/bin/kubectl-crossplane-stack-list
+++ b/bin/kubectl-crossplane-stack-list
@@ -32,4 +32,4 @@ if [[ $# -gt 0 ]]; then
   ALL_NAMESPACES=
 fi
 
-kubectl get stackrequests.stacks.crossplane.io ${ALL_NAMESPACES} "${@}"
+kubectl get stackinstalls.stacks.crossplane.io,clusterstackinstalls.stacks.crossplane.io ${ALL_NAMESPACES} "${@}"

--- a/bin/kubectl-crossplane-stack-uninstall
+++ b/bin/kubectl-crossplane-stack-uninstall
@@ -3,12 +3,13 @@
 set -e
 
 function usage {
-  echo "Usage: kubectl crossplane stack uninstall [-h|--help] STACK_NAME [options ...]" >&2
+  echo "Usage: kubectl crossplane stack uninstall [-h|--help] [-c|--cluster] STACK_NAME [options ...]" >&2
   echo "" >&2
   echo "STACK_NAME is the name of the stack to uninstall." >&2
   echo 'Namespace can also be passed, using the same syntax as a `kubectl delete` command.' >&2
   echo "" >&2
   echo "-h, --help: Print usage" >&2
+  echo "-c, --cluster: Uninstall a Cluster scoped stack" >&2
 }
 
 function check_help {
@@ -25,7 +26,15 @@ if [[ $# -lt 1 ]] ; then
   exit 1
 fi
 
+CLUSTER_OPT=${1}
+if [ "${CLUSTER_OPT}" == "-c" -o "${CLUSTER_OPT}" == "--cluster" ]; then
+  CLUSTER_STACK="cluster"
+  shift
+else
+  CLUSTER_STACK=""
+fi
+
 STACK_NAME="${1}"
 shift
 
-kubectl delete stackrequest "${STACK_NAME}" "$@"
+kubectl delete "${CLUSTER_STACK}"stackinstall "${STACK_NAME}" "$@"


### PR DESCRIPTION
Updates the CLI for the Crossplane Stacks updates in the v0.3 milestone
(metadata and isolation), requiring crossplaneio/crossplane#729.

New options for working with Cluster stacks:

* `stack init` now takes --cluster (-c)
* `stack install` now takes --cluster (-c)
* `stack uninstall` now takes --cluster (-c)
* `stack generate_install` now takes --cluster (-c)

Updated behavior:

* `stack list` now includes ClusterStackInstalls
* generate stub app.yaml files
  * when generating `app.yaml` files, set the `permissionScope` "Cluster" or "Namespaced"
* remove `rbac.yaml` which is now generated by the stack-manager
* Update the stack install example files to use the new kinds:
  `ClusterStackInstall` or `StackInstall`

Part of crossplaneio/crossplane#754
