### PR TITLE
Fixes for new functionality, with ports from the wordpress stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Here's the one-liner to do it:
 
 ```
-RELEASE=master && curl -s https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | RELEASE=${RELEASE} bash
+RELEASE=master && curl -sL https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | RELEASE=${RELEASE} bash
 ```
 
 The behavior is customizable via environment variables:
@@ -13,7 +13,7 @@ The behavior is customizable via environment variables:
 ```
 RELEASE=9760f8a7fd4fdd7f9a6cf3d5323a605412a65d11
 PREFIX=${HOME}
-curl -s https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | env PREFIX=${PREFIX} RELEASE=${RELEASE} bash
+curl -sL https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | env PREFIX=${PREFIX} RELEASE=${RELEASE} bash
 ```
 
 ### Installing from source
@@ -116,7 +116,7 @@ Copy the plugins to somewhere on your `PATH`. If you have
 `/usr/local/bin` on your `PATH`, you can do it like this:
 
 ```
-RELEASE=master && curl -s https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | RELEASE=${RELEASE} bash
+RELEASE=master && curl -sL https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | RELEASE=${RELEASE} bash
 ```
 
 ## Init project folder

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ the `crossplane stack init` command.
 From within the project directory:
 
 ```
-kubectl crossplane stack init 'crossplane-examples/hello-world'
+kubectl crossplane stack init --cluster 'crossplane-examples/hello-world'
 ```
 
 ## Set up the Hello World
@@ -210,7 +210,7 @@ When the stack is built, the next step is to install it into our
 Crossplane:
 
 ```
-kubectl crossplane stack install 'crossplane-examples/hello-world' 'crossplane-examples-hello-world' localhost:5000
+kubectl crossplane stack install --cluster 'crossplane-examples/hello-world' 'crossplane-examples-hello-world' localhost:5000
 ```
 
 This can also be done using the sample local stack install that the
@@ -252,7 +252,7 @@ When we're done with the stack and want to remove it and all its
 resources, we can `uninstall` it by name:
 
 ```
-kubectl crossplane stack uninstall 'crossplane-examples-hello-world'
+kubectl crossplane stack uninstall --cluster 'crossplane-examples-hello-world'
 ```
 
 ## How to build for external publishing
@@ -288,7 +288,7 @@ us by the `init` that we ran earlier, but it's a little easier to use
 the `install` command:
 
 ```
-kubectl crossplane stack install 'crossplane-examples/hello-world'
+kubectl crossplane stack install --cluster 'crossplane-examples/hello-world'
 ```
 
 ### Uninstall
@@ -298,7 +298,7 @@ generated for us by the `init` that we ran earlier, but it's a
 little easier to use the `uninstall` command:
 
 ```
-kubectl crossplane stack uninstall 'crossplane-examples-hello-world'
+kubectl crossplane stack uninstall --cluster 'crossplane-examples-hello-world'
 ```
 
 Note that `uninstall` uses the stack's name (which has no `/` characters),

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ kubectl crossplane stack init 'myname/mysubname'
 kubectl crossplane stack build
 kubectl crossplane stack publish
 kubectl crossplane stack install 'myname/mysubname'
+kubectl crossplane stack generate-install 'myname/mysubname' | kubectl apply --namespace mynamespace -f -
 kubectl crossplane stack list
 kubectl crossplane stack uninstall 'myname-mysubname'
 ```

--- a/README.md
+++ b/README.md
@@ -155,11 +155,7 @@ beginning with `export GO111MODULE=on`, or set in other ways.
 Next, create an API using `kubebuilder`:
 
 ```
-$ GO111MODULE=on kubebuilder create api --group samples --version v1alpha1 --kind HelloWorld
-> Create Resource [y/n]
-$ y
-> Create Controller [y/n]
-$ y
+yes y | GO111MODULE=on kubebuilder create api --group samples --version v1alpha1 --kind HelloWorld
 ```
 
 ## Initialize the stack project

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 Here's the one-liner to do it:
 
 ```
-RELEASE=master
-curl -s https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | bash
+RELEASE=master && curl -s https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | RELEASE=${RELEASE} bash
 ```
 
 The behavior is customizable via environment variables:
 
 ```
 RELEASE=9760f8a7fd4fdd7f9a6cf3d5323a605412a65d11
-curl -s https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | env PREFIX=${HOME} RELEASE=${RELEASE} bash
+PREFIX=${HOME}
+curl -s https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | env PREFIX=${PREFIX} RELEASE=${RELEASE} bash
 ```
 
 ### Installing from source
@@ -116,8 +116,7 @@ Copy the plugins to somewhere on your `PATH`. If you have
 `/usr/local/bin` on your `PATH`, you can do it like this:
 
 ```
-RELEASE=master
-curl -s https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | bash
+RELEASE=master && curl -s https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | RELEASE=${RELEASE} bash
 ```
 
 ## Init project folder

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -332,12 +332,6 @@ stack-uninstall:
 # Build the docker image
 docker-build: bundle
 	docker build --file stack.Dockerfile . -t ${STACK_IMG}
-	@echo "updating kustomize image patch file for manager resource"
-	@# The argument to sed -i and the subsequent rm make the in-place sed work well on MacOS.
-	@# There is no good way to do an in-place replacement with sed without leaving behind a
-	@# temporary file.
-	sed -i'.bak' -e 's@image: .*@image: '"${STACK_IMG}"'@' ./config/default/manager_image_patch.yaml
-	rm ./config/default/manager_image_patch.yaml.bak
 .PHONY: docker-build
 
 docker-push:

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -262,7 +262,7 @@ bundle: $(STACK_PACKAGE_REGISTRY)
 	# be to cat all of the files into a single crd.yaml.
 	find $(CRD_DIR) -type f -name '*.yaml' | \
 		while read filename ; do cat $$filename > \
-		$(STACK_PACKAGE_REGISTRY)/resources/$$( basename $$(echo $$filename | sed s/.yaml$$/.crd.yaml/))
+		$(STACK_PACKAGE_REGISTRY)/resources/$$( basename $$(echo $$filename | sed s/.yaml$$/.crd.yaml/)) \
 		; done
 
 	cp -r $(STACK_PACKAGE_REGISTRY_SOURCE)/* $(STACK_PACKAGE_REGISTRY)

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -262,7 +262,7 @@ bundle: $(STACK_PACKAGE_REGISTRY)
 	# be to cat all of the files into a single crd.yaml.
 	find $(CRD_DIR) -type f -name '*.yaml' | \
 		while read filename ; do cat $$filename > \
-		$(STACK_PACKAGE_REGISTRY)/resources/$$( basename $${filename/.yaml/.crd.yaml} ) \
+		$(STACK_PACKAGE_REGISTRY)/resources/$$( basename $$(echo $$filename | sed s/.yaml$$/.crd.yaml/))
 		; done
 
 	cp -r $(STACK_PACKAGE_REGISTRY_SOURCE)/* $(STACK_PACKAGE_REGISTRY)
@@ -272,7 +272,7 @@ bundle: $(STACK_PACKAGE_REGISTRY)
 # is convenient during development, as it simulates the whole lifecycle of the
 # Stack, end-to-end.
 docker-local-registry:
-	[[ $$( docker ps --filter name=registry --filter status=running --last 1 --quiet | wc -l ) -eq 1 ]] || \
+	[ $$( docker ps --filter name=registry --filter status=running --last 1 --quiet | wc -l ) -eq 1 ] || \
 		docker run -d -p 5000:5000 --restart=always --name registry registry:2
 .PHONY: docker-local-registry
 
@@ -336,7 +336,7 @@ docker-build: bundle
 	@# The argument to sed -i and the subsequent rm make the in-place sed work well on MacOS.
 	@# There is no good way to do an in-place replacement with sed without leaving behind a
 	@# temporary file.
-	sed -i '.bak' -e 's@image: .*@image: '"${STACK_IMG}"'@' ./config/default/manager_image_patch.yaml
+	sed -i'.bak' -e 's@image: .*@image: '"${STACK_IMG}"'@' ./config/default/manager_image_patch.yaml
 	rm ./config/default/manager_image_patch.yaml.bak
 .PHONY: docker-build
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,11 +12,11 @@ fi
 
 set -x
 
-curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-build https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-build >/dev/null
-curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-init https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-init >/dev/null
-curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-publish https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-publish >/dev/null
-curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-install https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-install >/dev/null
-curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-uninstall https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-uninstall >/dev/null
-curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-generate_install https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-generate_install >/dev/null
-curl -s -o "${PREFIX}"/bin/kubectl-crossplane-stack-list https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-list >/dev/null
+curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-stack-build https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-build >/dev/null
+curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-stack-init https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-init >/dev/null
+curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-stack-publish https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-publish >/dev/null
+curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-stack-install https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-install >/dev/null
+curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-stack-uninstall https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-uninstall >/dev/null
+curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-stack-generate_install https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-generate_install >/dev/null
+curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-stack-list https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-list >/dev/null
 chmod +x "${PREFIX}"/bin/kubectl-crossplane-stack-*

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -9,38 +9,42 @@
 set -e
 set -x
 
-TEST_DIR="${1}"
+TEST_DIR="${1:-test}"
 
+mkdir -p "${TEST_DIR}"
 cd "${TEST_DIR}"
 
 GO111MODULE=on kubebuilder init --domain helloworld.stacks.crossplane.io
 yes | GO111MODULE=on kubebuilder create api --group samples --version v1alpha1 --kind HelloWorld
 
-kubectl crossplane stack init 'crossplane-examples/hello-world'
+kubectl crossplane stack init --cluster 'crossplane-examples/hello-world'
 
-sed -i .bak -e 's/\/\/ your logic here/r.Log.V(0).Info("Hello World!", "instance", req.NamespacedName)/' controllers/helloworld_controller.go
+sed -i'.bak' -e 's/\/\/ your logic here/r.Log.V(0).Info("Hello World!", "instance", req.NamespacedName)/' controllers/helloworld_controller.go
 rm -f controllers/helloworld_controller.go.bak
 
 GO111MODULE=on make manager manifests
 kubectl crossplane stack build local-build
-kubectl crossplane stack install 'crossplane-examples/hello-world' 'crossplane-examples-hello-world' localhost:5000
+kubectl crossplane stack install --cluster 'crossplane-examples/hello-world' 'crossplane-examples-hello-world' localhost:5000
 
-done=true
+finished='false'
+set +e
 for i in $( seq 1 10 ); do
   echo "Attempt ${i} to create resource . . ." >&2
-  kubectl apply -f config/samples/*.yaml || done=false
+  kubectl apply -f config/samples/*.yaml
 
-  if [[ "${done}" == false ]]; then
+  if [[ $? -ne 0 ]]; then
     echo "Create failed. Waiting before retry. . ." >&2
     sleep 2
     continue
   else
+    finished='true'
     echo "Create SUCCESS" >&2
     break
   fi
 done
+set -e
 
-if [[ "${done}" == false ]]; then
+if [[ "${finished}" == 'false' ]]; then
   echo "Error: Couldn't create resource after retries!" >&2
   exit 1
 fi


### PR DESCRIPTION
## Overview

As part of updating the way the stacks manager works, we made some improvements and fixes to the wordpress stack. This changeset makes the same fixes for the Crossplane CLI. For example, crossplaneio/sample-stack-wordpress#10

This changeset also has various fixes that came about as part of testing and refining the Stacks Guide, such as the usage notes for `generate-install` and the changes to the bootstrap oneliner.

## Testing done

* Tested the individual steps in the quickstart
* Ran `make integration-test` locally and things worked as expected

## Notes for reviewers

This is more of an FYI than a merge that will block on getting a review. However, feel free to leave comments, and if the code is already merged, I will revisit the comments in a future changeset!