### PR TITLE
Add goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
-### binary ###
+# binary
 bin/kubectl-crossplane-trace
 
-### macOS ###
+# macOS
 .DS_Store
 
 .idea/
 .kube/
+
+# Release builds
+dist/
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -96,14 +96,16 @@ archives:
 
 checksum:
   name_template: 'checksums.txt'
+
 snapshot:
   name_template: "{{ .Tag }}-next"
+
 changelog:
   sort: asc
   filters:
     exclude:
-    - '^docs:'
     - '^test:'
+    - '^Merge pull request'
 
 release:
   # If set to true, will not auto-publish the release.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,14 +1,74 @@
-# This is an example goreleaser.yaml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
+# For more about how to configure goreleaser, see:
+# https://goreleaser.com/customization/
 before:
   hooks:
     # you may remove this if you don't use vgo
     - env GO111MODULE=on go mod tidy
 builds:
-- env:
-  - CGO_ENABLED=0
+# You can have multiple builds defined as a yaml list
+-
+  # ID of the build.
+  # Defaults to the project name.
+  id: "trace"
+
+  # Path to main.go file or main package.
+  # Default is `.`.
+  main: ./cmd/trace/main.go
+
+  # Binary name.
+  # Can be a path (e.g. `bin/app`) to wrap the binary in a directory.
+  # Default is the name of the project directory.
+  binary: "kubectl-crossplane-trace"
+
+  # Custom environment variables to be set during the builds.
+  # Default is empty.
+  env:
+    - CGO_ENABLED=0
+
 archives:
-- id: 'trace'
+-
+  # ID of this archive.
+  # Defaults to `default`.
+  id: "crossplane-cli"
+
+  # Builds reference which build instances should be archived in this archive.
+  builds:
+  - trace
+
+  # Archive name template.
+  # Defaults:
+  # - if format is `tar.gz`, `gz` or `zip`:
+  #   - `{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}`
+  # - if format is `binary`:
+  #   - `{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}`
+  # name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+  # Set to true, if you want all files in the archive to be in a single directory.
+  # If set to true and you extract the archive 'goreleaser_Linux_arm64.tar.gz',
+  # you get a folder 'goreleaser_Linux_arm64'.
+  # If set to false, all files are extracted separately.
+  # You can also set it to a custom folder name (templating is supported).
+  # Default is false.
+  # wrap_in_directory: true
+
+  # Archive format. Valid options are `tar.gz`, `gz`, `zip` and `binary`.
+  # If format is `binary`, no archives are created and the binaries are instead
+  # uploaded directly.
+  # Default is `tar.gz`.
+  format: "tar.gz"
+
+  # Can be used to change the archive formats for specific GOOSs.
+  # Most common use case is to archive as zip on Windows.
+  # Default is empty.
+  format_overrides:
+    - goos: windows
+      format: zip
+
+  # Additional files/globs you want to add to the archive.
+  # Defaults are any files matching `LICENCE*`, `LICENSE*`,
+  # `README*` and `CHANGELOG*` (case-insensitive).
+  files:
+    - 'NONE'
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,18 @@
 # For more about how to configure goreleaser, see:
 # https://goreleaser.com/customization/
+#
+# To release:
+# - Set the GITHUB_TOKEN environment variable
+# - Tag a commit with a release, such as 'v0.2.0'
+# - Push the tag
+# - Run `gorelease release` from the root of the repo.
+# - Follow the link which is printed to edit the draft release,
+#   then publish the release.
+#
+# NOTE: goreleaser will release to the github repo which is set
+# as the 'origin' remote.
+#
+# See https://goreleaser.com/release/ for more details.
 before:
   hooks:
     # you may remove this if you don't use vgo
@@ -91,3 +104,8 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
+
+release:
+  # If set to true, will not auto-publish the release.
+  # Default is false.
+  draft: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,7 @@ before:
   hooks:
     # you may remove this if you don't use vgo
     - env GO111MODULE=on go mod tidy
+    - make clean
 builds:
 # You can have multiple builds defined as a yaml list
 -
@@ -49,7 +50,10 @@ archives:
   #   - `{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}`
   # - if format is `binary`:
   #   - `{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}`
-  # name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  #
+  # We use the tag directly here so that the archive name matches the tag, which means it
+  # also matches the paths for the commands which are bash scripts.
+  name_template: "{{ .ProjectName }}_{{ .Tag }}_{{ .Os }}_{{ .Arch }}"
 
   # Set to true, if you want all files in the archive to be in a single directory.
   # If set to true and you extract the archive 'goreleaser_Linux_arm64.tar.gz',
@@ -71,6 +75,11 @@ archives:
   format_overrides:
     - goos: windows
       format: zip
+
+  # goreleaser will bundle other things into our archive for us, so we're using
+  # that functionality to bundle our bash scripts into the archive.
+  files:
+    - bin/kubectl-crossplane-*
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,21 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    # you may remove this if you don't use vgo
+    - env GO111MODULE=on go mod tidy
+builds:
+- env:
+  - CGO_ENABLED=0
+archives:
+- id: 'trace'
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,12 +18,20 @@ builds:
   # Binary name.
   # Can be a path (e.g. `bin/app`) to wrap the binary in a directory.
   # Default is the name of the project directory.
-  binary: "kubectl-crossplane-trace"
+  #
+  # Putting the binary in a folder allows us to put some documentation
+  # in the archive root, while also extracting all binary files into
+  # the destination directory in a single command.
+  binary: "bin/kubectl-crossplane-trace"
 
   # Custom environment variables to be set during the builds.
   # Default is empty.
   env:
     - CGO_ENABLED=0
+    - GO111MODULE=on
+
+  goarch:
+  - amd64
 
 archives:
 -
@@ -64,11 +72,6 @@ archives:
     - goos: windows
       format: zip
 
-  # Additional files/globs you want to add to the archive.
-  # Defaults are any files matching `LICENCE*`, `LICENSE*`,
-  # `README*` and `CHANGELOG*` (case-insensitive).
-  files:
-    - 'NONE'
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test:
 .PHONY: test
 
 clean:
-	rm bin/kubectl-crossplane-trace
+	rm -f bin/kubectl-crossplane-trace
 .PHONY: clean
 
 install:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -27,7 +27,7 @@ if [[ "${RELEASE}" == "master" ]]; then
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-stack-generate_install https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-generate_install >/dev/null
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-stack-list https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-list >/dev/null
 else
-  curl -sL https://github.com/crossplaneio/crossplane-cli/releases/download/"${RELEASE}"/crossplane-cli-"${RELEASE}"-"${PLATFORM}".tar.gz | tar -xz --strip 1 -C "${PREFIX}"/bin
+  curl -sL https://github.com/crossplaneio/crossplane-cli/releases/download/"${RELEASE}"/crossplane-cli_"${RELEASE}"_"${PLATFORM}"_amd64.tar.gz | tar -xz --strip 1 -C "${PREFIX}"/bin
 fi
 
 chmod +x "${PREFIX}"/bin/kubectl-crossplane-*

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -27,6 +27,7 @@ if [[ "${RELEASE}" == "master" ]]; then
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-stack-generate_install https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-generate_install >/dev/null
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-stack-list https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-list >/dev/null
 else
-  curl -sL https://github.com/crossplaneio/crossplane-cli/releases/download/"${RELEASE}"/crossplane-cli-"${RELEASE}"-"${PLATFORM}".tar.gz | tar xz --strip 1 -C "${PREFIX}"/bin
+  curl -sL https://github.com/crossplaneio/crossplane-cli/releases/download/"${RELEASE}"/crossplane-cli-"${RELEASE}"-"${PLATFORM}".tar.gz | tar -xz --strip 1 -C "${PREFIX}"/bin
 fi
-chmod +x "${PREFIX}"/bin/kubectl-crossplane-stack-*
+
+chmod +x "${PREFIX}"/bin/kubectl-crossplane-*

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -27,7 +27,7 @@ if [[ "${RELEASE}" == "master" ]]; then
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-stack-generate_install https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-generate_install >/dev/null
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-stack-list https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-stack-list >/dev/null
 else
-  curl -sL https://github.com/crossplaneio/crossplane-cli/releases/download/"${RELEASE}"/crossplane-cli_"${RELEASE}"_"${PLATFORM}"_amd64.tar.gz | tar -xz --strip 1 -C "${PREFIX}"/bin
+  curl -sL https://github.com/crossplaneio/crossplane-cli/releases/download/"${RELEASE}"/crossplane-cli_"${RELEASE}"_"${PLATFORM}"_amd64.tar.gz | tar -xz -v --strip 1 -C "${PREFIX}"/bin
 fi
 
 chmod +x "${PREFIX}"/bin/kubectl-crossplane-*

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	golang.org/x/net v0.0.0-20191014212845-da9a3fd4c582 // indirect
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 // indirect
-	gopkg.in/yaml.v2 v2.2.4
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/utils v0.0.0-20191010214722-8d271d903fe4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,7 @@ github.com/Azure/go-autorest/autorest/date v0.2.0 h1:yW+Zlqf26583pE43KhfnhFcdmSW
 github.com/Azure/go-autorest/autorest/date v0.2.0/go.mod h1:vcORJHLJEh643/Ioh9+vPmf1Ij9AEBM5FuBIXLmIy0g=
 github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
+github.com/Azure/go-autorest/autorest/mocks v0.3.0 h1:qJumjCaCudz+OcqE9/XtEPfvtOjOmKaui4EOpFI6zZc=
 github.com/Azure/go-autorest/autorest/mocks v0.3.0/go.mod h1:a8FDP3DYzQ4RYfVAxAN3SVSiiO77gL2j2ronKKP0syM=
 github.com/Azure/go-autorest/logger v0.1.0 h1:ruG4BSDXONFRrZZJ2GUXDiUyVpayPmb1GnWeHDdaNKY=
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
@@ -41,6 +42,7 @@ github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5I
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -49,6 +51,7 @@ github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V
 github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/zapr v0.1.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
+github.com/go-logr/zapr v0.1.1 h1:qXBXPDdNncunGs7XeEpsJt8wCjYBygluzfdLO0G5baE=
 github.com/go-logr/zapr v0.1.1/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
@@ -167,9 +170,12 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
+go.uber.org/zap v1.10.0 h1:ORx85nbTijNz8ljznvCMR1ZBIPKFn3jQrag10X2AsuM=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180820150726-614d502a4dac/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=


### PR DESCRIPTION
## Overview

Now that we have our first go command (/ht @turkenh), we want the release process to be as painless and automated as possible. This changeset adds some configuration to do that by integrating with [goreleaser](https://goreleaser.com). Over time, we may make some more customizations and improvements, and add support for more platforms.

The biggest change for this integration is that everything will now be bundled into a single `tar.gz` file, including the go binaries and the bash scripts.

As part of cutting a release, we will want to also update the documentation and the `bootstrap.sh` to default to the latest explicit release. Binary commands will not be available from master yet, though it looks like we can also use goreleaser to build and upload snapshots.

## Testing done

* I followed the release steps locally, and it created a draft release for me in my fork.
* I created the tar.gz files a few times and tried them with the `tar` command from `bootstrap.sh` (only on darwin; if someone wants to test on linux I would appreciate that)