### PR TITLE
docs: update versions to point at 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,27 @@ curl -sL https://raw.githubusercontent.com/crossplaneio/crossplane-cli/master/bo
 The behavior is customizable via environment variables:
 
 ```
-RELEASE=v0.1.0
+RELEASE=v0.2.0
 PREFIX=${HOME}
 curl -sL https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | env PREFIX=${PREFIX} RELEASE=${RELEASE} bash
 ```
 
-You can get latest master for `stack` commands by setting `RELEASE` as `master`. But please note, `trace` command will 
-not be installed in this case.
+You can get the latest, bleeding-edge versions of the `stack` commands
+by setting `RELEASE` as `master`.
 
 ```
 RELEASE=master && curl -sL https://raw.githubusercontent.com/crossplaneio/crossplane-cli/"${RELEASE}"/bootstrap.sh | RELEASE=${RELEASE} bash
 ```
 
+But please note, the `trace` command will not be installed in this case,
+because it's a built binary and isn't set up to be easily downloaded
+from `master`. To use `trace` from `master`, we recommend building and
+installing from source.
+
 ### Installing from source
 
-If you have the source repository checked out, installing is simple as long as you have `golang` installed:
+If you have the source repository checked out, installing is simple as
+long as you have `golang` installed:
 
 ```
 make build
@@ -58,7 +64,7 @@ make uninstall
 
 ## Usage
 
-### Stack commands 
+### Stack commands
 
 ```
 kubectl crossplane stack init 'myname/mysubname'


### PR DESCRIPTION
## Overview

Now that we're about to release version 0.2.0, we want to update our
docs to mention that version by default. This also adds some small clarifications.

After this, we should be good to release version 0.2.0 by following the instructions in the goreleaser configuration file.