### PR TITLE
add bare commands to offer command help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean:
 .PHONY: clean
 
 install:
-	ln -si $(abspath bin/kubectl-crossplane-*) $(INSTALL_DIR)/
+	ln -si $(abspath bin/kubectl-crossplane*) $(INSTALL_DIR)/
 .PHONY: install
 
 uninstall:

--- a/bin/kubectl-crossplane
+++ b/bin/kubectl-crossplane
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+function usage {
+  echo "Usage: kubectl crossplane [-h|--help] [COMMAND]... [OPTION]... [ARGUMENT]..." >&2
+  echo "" >&2
+  echo "Commands:" >&2
+  echo "  stack" >&2
+  echo "  trace" >&2
+  echo "" >&2
+  echo "-h, --help: Print usage" >&2
+  echo "" >&2
+}
+
+function check_help {
+  if [ "${1}" == "-h" -o "${1}" == "--help" ] ; then
+    usage
+    exit 1
+  fi
+}
+
+check_help "${1}"
+
+if [[ $# -lt 1 ]] ; then
+  usage
+  exit 1
+fi

--- a/bin/kubectl-crossplane-stack
+++ b/bin/kubectl-crossplane-stack
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+function usage {
+  echo "Usage: kubectl crossplane [-h|--help] stack [COMMAND] [OPTION]... [ARGUMENT]..." >&2
+  echo "" >&2
+  echo "Commands (Stack):" >&2
+  echo "  build" >&2
+  echo "  generate-install" >&2
+  echo "  init" >&2
+  echo "  install" >&2
+  echo "  list" >&2
+  echo "  publish" >&2
+  echo "  uninstall" >&2
+  echo "" >&2
+  echo "-h, --help: Print usage" >&2
+  echo "" >&2
+}
+
+function check_help {
+  if [ "${1}" == "-h" -o "${1}" == "--help" ] ; then
+    usage
+    exit 1
+  fi
+}
+
+check_help "${1}"
+
+if [[ $# -lt 1 ]] ; then
+  usage
+  exit 1
+fi


### PR DESCRIPTION
Add the following bare commands to offer help:

* `kubectl crossplane`
* `kubectl crossplane stack`

Each command lists the available subcommands and accepts `-h` for help

Closes #13