### PR TITLE
add wrapper and update packaging for use by krew

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -93,6 +93,7 @@ archives:
   # that functionality to bundle our bash scripts into the archive.
   files:
     - bin/kubectl-crossplane-*
+    - LICENSE
 
 checksum:
   name_template: 'checksums.txt'

--- a/bin/kubectl-crossplane
+++ b/bin/kubectl-crossplane
@@ -22,7 +22,9 @@ function check_help {
 
 check_help "${1}"
 
-if [[ $# -lt 1 ]] ; then
-  usage
-  exit 1
+if [[ $# -gt 0 ]] ; then
+  echo "Unknown command: $1" >&2
 fi
+
+usage
+exit 1

--- a/bin/kubectl-crossplane-krew-wrapper
+++ b/bin/kubectl-crossplane-krew-wrapper
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Wrapper to unify all crossplane-cli plugin commands
+# for use by krew
+
+set -e
+BASEDIR=$(dirname $(realpath "$0"))
+
+PATH="${BASEDIR}:${PATH}" exec kubectl crossplane "$@"


### PR DESCRIPTION
Closes #32 by adding LICENSE to the goreleaser tarball and adding a wrapper script for krew to use as a single point of entry for the Crossplane CLI plugins.

The (expected) krew-index manifest yaml:
https://gist.github.com/displague/444bb96b0419a036f51bf40098538a65

The plugin can be installed/tested from this branch by first removing any already installed cropssplane-cli utilities from the path and then running:

```
tar czvf /tmp/crossplane-krew-archive.tgz .
shasum -256 /tmp/crossplane-krew-archive.tgz 
# create /tmp/crossplane-krew-manifest from the gist above, update the sha256 from above
kubectl krew install --manifest=/tmp/crossplane-krew-manifest --archive=/tmp/crossplane-krew-archive.tgz
```