### PR TITLE
build and publish: use `Makefile` if `stack.Makefile` not found

### DIFF
--- a/bin/kubectl-crossplane-stack-build
+++ b/bin/kubectl-crossplane-stack-build
@@ -30,4 +30,10 @@ shift
 set -e
 set -x
 
-make -f stack.Makefile ${COMMAND} "$@"
+# If stack.Makefile exists, we want to use that. Otherwise,
+# we'll use a regular Makefile.
+if [[ -e stack.Makefile ]]; then
+  make -f stack.Makefile ${COMMAND} "$@"
+else
+  make ${COMMAND} "$@"
+fi

--- a/bin/kubectl-crossplane-stack-publish
+++ b/bin/kubectl-crossplane-stack-publish
@@ -41,4 +41,12 @@ fi
 
 set -x
 
-make -f stack.Makefile publish
+COMMAND=publish
+
+# If stack.Makefile exists, we want to use that. Otherwise,
+# we'll use a regular Makefile.
+if [[ -e stack.Makefile ]]; then
+  make -f stack.Makefile ${COMMAND} "$@"
+else
+  make ${COMMAND} "$@"
+fi


### PR DESCRIPTION
Related to #40

## Overview

For template stacks, we have much simpler stack source repositories, and
we don't always need to have a separate `stack.Makefile`. This adds
support for using just a regular, standard `Makefile` if
`stack.Makefile` is not found.

## Testing done

I've tested this locally with the sample wordpress stack with the `stack.Makefile` present and not present.