### PR TITLE
[WIP] stacks: Put CRD yaml files in apiGroup directories

### DIFF
--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -263,8 +263,11 @@ bundle: $(STACK_PACKAGE_REGISTRY)
 	# An alternate and simpler-looking approach would
 	# be to cat all of the files into a single crd.yaml.
 	find $(CRD_DIR) -type f -name '*.yaml' | \
-		while read filename ; do cat $$filename > \
-		$(STACK_PACKAGE_REGISTRY)/resources/$$( basename $$(echo $$filename | sed s/.yaml$$/.crd.yaml/)) \
+		while read filename ; do \
+		mkdir -p $(STACK_PACKAGE_REGISTRY)/resources/$$(basename $${filename%_*}); \
+		concise=$${filename#*_}; \
+		cat $$filename > \
+		$(STACK_PACKAGE_REGISTRY)/resources/$$( basename $${filename%_*} )/$$( basename $${concise/.yaml/.crd.yaml} ) \
 		; done
 
 	cp -r $(STACK_PACKAGE_REGISTRY_SOURCE)/* $(STACK_PACKAGE_REGISTRY)

--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -64,6 +64,7 @@ function create_manifest {
   mkdir -p config/stack/manifests
   touch config/stack/manifests/app.yaml
   cat > config/stack/manifests/app.yaml <<EOF
+apiVersion: 0.1.0
 title: ""
 readme: ""
 overview: ""


### PR DESCRIPTION
Borrows from crossplane/stack-gcp#190 (@hasheddan) so future stacks can benefit from using the API group in the Stack .resource/ tree.

Adds the default app.yaml APIVersion of 0.1.0 in a separate commit which can be moved to another PR if preferred.

WIP - because this hasn't been run yet