### PR TITLE
init: omit controller image

### DIFF
--- a/bin/kubectl-crossplane-stack-init
+++ b/bin/kubectl-crossplane-stack-init
@@ -110,7 +110,12 @@ spec:
     spec:
       containers:
       - name: "${KUBEY_STACK_NAME}-controller"
-        image: "${STACK_IMAGE_NAME}"
+        # The `image:` field is optional. If omitted, it will be
+        # filled in by the stack manager, using the same image
+        # name and tag as the package on the StackInstall object.
+        # We recommend omitting it unless you know you need it.
+        #
+        # image: "${STACK_IMAGE_NAME}"
         env:
         - name: POD_NAME
           valueFrom:
@@ -149,16 +154,6 @@ spec:
 EOF
   echo 'Created config/stack/samples/install.stack.yaml' >&2
 
-  mkdir -p config/stack/overrides
-  cat > config/stack/overrides/install.yaml <<EOF
-spec:
-  template:
-    spec:
-      containers:
-      - name: "${KUBEY_STACK_NAME}-controller"
-        image: "localhost:5000/${STACK_IMAGE_NAME}"
-EOF
-  echo 'Created config/stack/overrides/install.yaml' >&2
 }
 
 function check_for_existing_stack {


### PR DESCRIPTION
Related to crossplane/crossplane#1308

Now that we support omitting the controller image, it's easier as an
author if we omit it.

## Testing

Omitting the image field has been tested with other stacks; I tested it with the latest version of Crossplane and `provider-gcp` and `stack-minimal-gcp` on my machine.

I also tested generating the `install.yaml` locally by running the init command, and it came out as expected.