### PR TITLE
add 'registry login' via docker login

### DIFF
--- a/bin/kubectl-crossplane
+++ b/bin/kubectl-crossplane
@@ -8,6 +8,7 @@ function usage {
   echo "Commands:" >&2
   echo "  stack" >&2
   echo "  trace" >&2
+  echo "  registry" >&2
   echo "" >&2
   echo "-h, --help: Print usage" >&2
   echo "" >&2

--- a/bin/kubectl-crossplane-registry
+++ b/bin/kubectl-crossplane-registry
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -e
+
+function usage {
+  echo "Usage: kubectl crossplane registry [-h|--help] [COMMAND]... [OPTION]... [ARGUMENT]..." >&2
+  echo "" >&2
+  echo "Commands:" >&2
+  echo "  login" >&2
+  echo "" >&2
+  echo "-h, --help: Print usage" >&2
+  echo "" >&2
+}
+
+POSITIONAL=()
+
+while [[ $# -gt 0 ]]; do
+  opt="$1"
+
+  case $opt in
+    -h|--help)
+      usage
+      exit 1
+      ;;
+    -*)
+      echo "Unknown argument: $opt" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ "${#POSITIONAL[@]}" -eq "0" ]; then
+  echo "Missing arguments" >&2
+  usage
+  exit 1
+fi
+
+if [[ $# -gt 0 ]] ; then
+  echo "Unknown command: $1" >&2
+fi
+
+usage
+exit 1

--- a/bin/kubectl-crossplane-registry-login
+++ b/bin/kubectl-crossplane-registry-login
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -e
+
+function usage {
+  echo "Usage: kubectl crossplane registry login [-h|--help] SERVER [ARGS]..." >&2
+  echo "" >&2
+  echo "SERVER is the image registry server where the provided credentials will be authenticated." >&2
+  echo "" >&2
+  echo "ARGS are additional parameters to pass through to 'docker login'." >&2
+  echo "  -p, --password string   Password" >&2
+  echo "      --password-stdin    Take the password from stdin" >&2
+  echo "  -u, --username string   Username" >&2
+  echo "" >&2
+  echo "Examples:" >&2
+  echo "" >&2
+  echo "Login to the Upbound registry:" >&2
+  echo "kubectl crossplane registry login registry.upbound.io" >&2
+  echo "" >&2
+  echo "-h, --help: Print usage" >&2
+  echo "" >&2
+}
+
+POSITIONAL=()
+ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  opt="$1"
+
+  case $opt in
+    -h|--help)
+      usage
+      exit 1
+      ;;
+    -p|--password)
+      if [ -z "$2" ]; then
+        echo "Missing password" >&2
+        usage
+        exit 1
+      fi
+      ARGS+=("$1" "$2")
+      shift
+      shift
+      ;;
+    -u|--username)
+      if [ -z "$2" ]; then
+        echo "Missing username" >&2
+        usage
+        exit 1
+      fi
+      ARGS+=("$1" "$2")
+      shift
+      shift
+      ;;
+    -*)
+      # pass-through any --key=value or arguments without values
+      ARGS+=("$1")
+      shift
+      ;;
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ "${#POSITIONAL[@]}" -eq "0" ]; then
+  echo "Missing registry argument" >&2
+  usage
+  exit 1
+fi
+
+# Reset the positional parameters ($1, ..) from the array of arguments
+# that didn't match our known options
+set -- "${POSITIONAL[@]}"
+
+SERVER="$1"
+
+docker login "$SERVER" "${ARGS[@]}"

--- a/bin/kubectl-crossplane-stack-build
+++ b/bin/kubectl-crossplane-stack-build
@@ -1,10 +1,26 @@
 #!/usr/bin/env bash
 
 function usage {
-  echo "Usage: kubectl crossplane stack [-h|--help] build [ARGS ...]" >&2
+  echo "Usage: kubectl crossplane stack [-h|--help] build [STACK_IMAGE_NAME] [ARGS ...]" >&2
   echo "" >&2
-  echo "ARGS: An alternate recipe to build, or other arguments to pass through" >&2
-  echo 'to `make`.' >&2
+  echo "" >&2
+  echo "STACK_IMAGE_NAME is the name that will be given to the built image." >&2
+  echo "Like any image name in the local docker registry, this may start">&2
+  echo "with a server address and end with a tag. If unspecified," >&2
+  echo "it will use whatever name the project was initialized with." >&2
+  echo "" >&2
+  echo 'ARGS are other arguments to pass through to `make build`.' >&2
+  echo "" >&2
+  echo "Examples:" >&2
+  echo "" >&2
+  echo "Build a stack and tag it with the default image name:" >&2
+  echo "kubectl crossplane stack build" >&2
+  echo "" >&2
+  echo "Build a stack and tag it for publishing to a local registry:" >&2
+  echo "kubectl crossplane stack build localhost:5000/mystackrepository/mystackimagename" >&2
+  echo "" >&2
+  echo "Build a stack and tag it for publishing to a public registry:" >&2
+  echo "kubectl crossplane stack build registry.upbound.io/username/repo-name:v0.0.1" >&2
   echo "" >&2
   echo "-h, --help: Print usage" >&2
 }
@@ -18,11 +34,7 @@ function check_help {
 
 check_help "${1}"
 
-# We could also have just passed all the arguments through
-# instead of extracting the command out, but it seems more
-# clear what is happening in the no-argument case if the
-# command is split out.
-COMMAND=${1:-build}
+STACK_IMG=${1}
 shift
 
 # Shift returns non-zero if there are no arguments left,
@@ -33,7 +45,7 @@ set -x
 # If stack.Makefile exists, we want to use that. Otherwise,
 # we'll use a regular Makefile.
 if [[ -e stack.Makefile ]]; then
-  make -f stack.Makefile ${COMMAND} "$@"
+  make -f stack.Makefile build ${STACK_IMG:+"STACK_IMG=$STACK_IMG"} "$@"
 else
-  make ${COMMAND} "$@"
+  make build ${STACK_IMG:+"STACK_IMG=$STACK_IMG"} "$@"
 fi


### PR DESCRIPTION
Fixes crossplane/crossplane-cli#44

* add 'registry login' via docker login
* change 'stack build' to take an image parameter
* change 'stack build' to pass additional arguments to 'make build', not 'make'
