### PR TITLE
[Bug] Seed using time.Now to ensure different random number on each run of pack command

### DIFF
--- a/cmd/pack/main.go
+++ b/cmd/pack/main.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"math/rand"
 	"os"
+	"time"
 
 	"github.com/spf13/pflag"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,6 +41,7 @@ type packOptions struct {
 var pOpts = &packOptions{}
 
 func init() {
+	rand.Seed(time.Now().UnixNano())
 	pflag.BoolVarP(&pOpts.help, "help", "h", false, "Shows this help message")
 	pflag.StringVarP(&pOpts.useFile, "file", "f", "", "Specifies file path to read from")
 	pflag.StringVar(&pOpts.name, "name", fmt.Sprintf("app-%s", fmt.Sprint(rand.Intn(50000))), "Name")


### PR DESCRIPTION
Currently the pack command will append the same number on each run (when `--name` is not supplied) because the random generator is not being seeded with a changing value. This reseeds the random generator one each run with the current time.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>