### PR TITLE
Add registry and help commands to bootstrap script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,6 +21,8 @@ if [[ "${RELEASE}" == "master" || "${RELEASE}" == release-0.1 ]]; then
   set +x
   echo "NOTICE: the trace and pack commands are not available from master. RELEASE must be set to a released version (such as v0.2.0). See https://github.com/crossplane/crossplane-cli/releases for the full list of releases." >&2
   set -x
+  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane >/dev/null
+  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-krew-wrapper https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-krew-wrapper >/dev/null
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package >/dev/null
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-build https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-build >/dev/null
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-init https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-init >/dev/null
@@ -29,8 +31,8 @@ if [[ "${RELEASE}" == "master" || "${RELEASE}" == release-0.1 ]]; then
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-uninstall https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-uninstall >/dev/null
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-generate_install https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-generate_install >/dev/null
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-list https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-list >/dev/null
-  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-registry https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-registry >/dev/null
-  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-registry-login https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-registry-login >/dev/null
+  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-registry https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-registry >/dev/null
+  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-registry-login https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-registry-login >/dev/null
 else
   curl -sL https://github.com/crossplane/crossplane-cli/releases/download/"${RELEASE}"/crossplane-cli_"${RELEASE}"_"${PLATFORM}"_amd64.tar.gz | tar -xz -v --strip 1 -C "${PREFIX}"/bin
 fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,6 +21,7 @@ if [[ "${RELEASE}" == "master" || "${RELEASE}" == release-0.1 ]]; then
   set +x
   echo "NOTICE: the trace and pack commands are not available from master. RELEASE must be set to a released version (such as v0.2.0). See https://github.com/crossplane/crossplane-cli/releases for the full list of releases." >&2
   set -x
+  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package >/dev/null
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-build https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-build >/dev/null
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-init https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-init >/dev/null
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-publish https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-publish >/dev/null
@@ -28,6 +29,8 @@ if [[ "${RELEASE}" == "master" || "${RELEASE}" == release-0.1 ]]; then
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-uninstall https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-uninstall >/dev/null
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-generate_install https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-generate_install >/dev/null
   curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-list https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-list >/dev/null
+  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-registry https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-registry >/dev/null
+  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-registry-login https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-registry-login >/dev/null
 else
   curl -sL https://github.com/crossplane/crossplane-cli/releases/download/"${RELEASE}"/crossplane-cli_"${RELEASE}"_"${PLATFORM}"_amd64.tar.gz | tar -xz -v --strip 1 -C "${PREFIX}"/bin
 fi


### PR DESCRIPTION
Looks like these commands were never added to `bootstrap.sh`  when they were created.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>