### PR TITLE
update patterns for install/uninstall to also include the root crossplane command

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -102,7 +102,7 @@ archives:
   # goreleaser will bundle other things into our archive for us, so we're using
   # that functionality to bundle our bash scripts into the archive.
   files:
-    - bin/kubectl-crossplane-*
+    - bin/kubectl-crossplane*
     - LICENSE
 
 checksum:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install:
 .PHONY: install
 
 uninstall:
-	rm $(INSTALL_DIR)/kubectl-crossplane-*
+	rm $(INSTALL_DIR)/kubectl-crossplane*
 .PHONY: uninstall
 
 integration-test:

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ If you followed the installation process above, you can remove
 everything with:
 
 ```
-rm /usr/local/bin/kubectl-crossplane-*
+rm /usr/local/bin/kubectl-crossplane*
 ```
 
 Or, if you customized the installation prefix:
 
 ```
 PREFIX=/thing
-rm "${PREFIX}"/bin/kubectl-crossplane-*
+rm "${PREFIX}"/bin/kubectl-crossplane*
 ```
 
 ### Uninstalling from source

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -37,4 +37,4 @@ else
   curl -sL https://github.com/crossplane/crossplane-cli/releases/download/"${RELEASE}"/crossplane-cli_"${RELEASE}"_"${PLATFORM}"_amd64.tar.gz | tar -xz -v --strip 1 -C "${PREFIX}"/bin
 fi
 
-chmod +x "${PREFIX}"/bin/kubectl-crossplane-*
+chmod +x "${PREFIX}"/bin/kubectl-crossplane*


### PR DESCRIPTION
This PR updates the patterns used for install and uninstall to include all `kubectl-crossplane*` hits, which covers the root `kubectl-crossplane` command.  This command was being missed for removal and `chmod +x`.

How was this tested?  I tested the local `make install` and `make uninstall`, and also executed the updated `bootstrap.sh` script.  All expected commands were installed as executable into `/usr/local/bin` and removed cleanly.

After install:
```
> ll /usr/local/bin/kubectl*
-rwxr-xr-x  1 jared  staff    46M Jul 26  2019 /usr/local/bin/kubectl*
-rwxr-xr-x  1 jared  admin   507B Apr 28 15:49 /usr/local/bin/kubectl-crossplane*
-rwxr-xr-x  1 jared  admin   193B Apr 28 15:49 /usr/local/bin/kubectl-crossplane-krew-wrapper*
-rwxr-xr-x  1 jared  admin   586B Apr 28 15:49 /usr/local/bin/kubectl-crossplane-package*
-rwxr-xr-x  1 jared  admin   1.6K Apr 28 15:49 /usr/local/bin/kubectl-crossplane-package-build*
-rwxr-xr-x  1 jared  admin   2.5K Apr 28 15:49 /usr/local/bin/kubectl-crossplane-package-generate_install*
-rwxr-xr-x  1 jared  admin    10K Apr 28 15:49 /usr/local/bin/kubectl-crossplane-package-init*
-rwxr-xr-x  1 jared  admin   2.8K Apr 28 15:49 /usr/local/bin/kubectl-crossplane-package-install*
-rwxr-xr-x  1 jared  admin   1.0K Apr 28 15:49 /usr/local/bin/kubectl-crossplane-package-list*
-rwxr-xr-x  1 jared  admin   1.4K Apr 28 15:49 /usr/local/bin/kubectl-crossplane-package-publish*
-rwxr-xr-x  1 jared  admin   868B Apr 28 15:49 /usr/local/bin/kubectl-crossplane-package-uninstall*
-rwxr-xr-x  1 jared  admin   703B Apr 28 15:49 /usr/local/bin/kubectl-crossplane-registry*
-rwxr-xr-x  1 jared  admin   1.6K Apr 28 15:49 /usr/local/bin/kubectl-crossplane-registry-login*
lrwxr-xr-x  1 root   admin    55B Feb  4 16:09 /usr/local/bin/kubectl.docker@ -> /Applications/Docker.app/Contents/Resources/bin/kubectl
```

After uninstall:
```
> ll /usr/local/bin/kubectl*
-rwxr-xr-x  1 jared  staff    46M Jul 26  2019 /usr/local/bin/kubectl*
lrwxr-xr-x  1 root   admin    55B Feb  4 16:09 /usr/local/bin/kubectl.docker@ -> /Applications/Docker.app/Contents/Resources/bin/kubectl
```