### PR TITLE
Change commands to work with Package types

### DIFF
--- a/bin/kubectl-crossplane-package
+++ b/bin/kubectl-crossplane-package
@@ -5,7 +5,7 @@ set -e
 function usage {
   echo "Usage: kubectl crossplane [-h|--help] package [COMMAND] [OPTION]... [ARGUMENT]..." >&2
   echo "" >&2
-  echo "Commands (Stack):" >&2
+  echo "Commands (Package):" >&2
   echo "  build" >&2
   echo "  generate-install" >&2
   echo "  init" >&2

--- a/bin/kubectl-crossplane-package-generate_install
+++ b/bin/kubectl-crossplane-package-generate_install
@@ -14,10 +14,10 @@ function usage {
   echo "converted to '-' characters." >&2
   echo "" >&2
   echo "-h, --help: Print usage" >&2
-  echo "-c, --cluster: generate a ClusterStackInstall for Packages with Cluster permission scope" >&2
+  echo "-c, --cluster: generate a ClusterPackageInstall for Packages with Cluster permission scope" >&2
 }
 
-CLUSTER_STACK=""
+CLUSTER_PACKAGE=""
 IMAGE_PULL_SECRET=""
 POSITIONAL=()
 
@@ -26,7 +26,7 @@ while [[ $# -gt 0 ]]; do
 
   case $opt in
     -c|--cluster)
-      CLUSTER_STACK="Cluster"
+      CLUSTER_PACKAGE="Cluster"
       shift
       ;;
     --imagePullSecret=*)
@@ -105,8 +105,8 @@ if [[ -n "${SECRET_SNIPPET}" ]]; then
 fi
 
 INSTALL_YAML="$( cat <<EOF
-apiVersion: stacks.crossplane.io/v1alpha1
-kind: ${CLUSTER_STACK}StackInstall
+apiVersion: packages.crossplane.io/v1alpha1
+kind: ${CLUSTER_PACKAGE}PackageInstall
 metadata:
   name: "${PACKAGE_NAME}"
 spec:

--- a/bin/kubectl-crossplane-package-init
+++ b/bin/kubectl-crossplane-package-init
@@ -11,7 +11,7 @@ function usage {
   echo "DIRECTORY defaults to the current directory." >&2
   echo "" >&2
   echo "-f, --force: force init when a previous 'package init' is detected" >&2
-  echo "-c, --cluster: use the Cluster Package permission scope and generate ClusterStackInstall examples" >&2
+  echo "-c, --cluster: use the Cluster Package permission scope and generate ClusterPackageInstall examples" >&2
   echo "-h, --help: Print usage" >&2
 }
 
@@ -38,11 +38,11 @@ fi
 
 CLUSTER_OPT=${1}
 if [ "${CLUSTER_OPT}" == "-c" -o "${CLUSTER_OPT}" == "--cluster" ]; then
-  CLUSTER_STACK="Cluster"
+  CLUSTER_PACKAGE="Cluster"
   PACKAGE_SCOPE="Cluster"
   shift
 else
-  CLUSTER_STACK=""
+  CLUSTER_PACKAGE=""
   PACKAGE_SCOPE="Namespaced"
 fi
 
@@ -111,8 +111,8 @@ spec:
       containers:
       - name: "${KUBEY_PACKAGE_NAME}-controller"
         # The `image:` field is optional. If omitted, it will be
-        # filled in by the stack manager, using the same image
-        # name and tag as the package on the StackInstall object.
+        # filled in by the package manager, using the same image
+        # name and tag as the package on the PackageInstall object.
         # We recommend omitting it unless you know you need it.
         #
         # image: "${PACKAGE_IMAGE_NAME}"
@@ -131,28 +131,28 @@ EOF
 
 function create_samples {
   mkdir -p config/package/samples
-  cat > config/package/samples/local.install.stack.yaml <<EOF
+  cat > config/package/samples/local.install.package.yaml <<EOF
 ---
-apiVersion: stacks.crossplane.io/v1alpha1
-kind: ${CLUSTER_STACK}StackInstall
+apiVersion: packagess.crossplane.io/v1alpha1
+kind: ${CLUSTER_PACKAGE}PackageInstall
 metadata:
   name: "${KUBEY_PACKAGE_NAME}"
 spec:
   source: localhost:5000
   package: "${PACKAGE_IMAGE_NAME}"
 EOF
-  echo 'Created config/package/samples/local.install.stack.yaml' >&2
+  echo 'Created config/package/samples/local.install.package.yaml' >&2
 
-  cat > config/package/samples/install.stack.yaml <<EOF
+  cat > config/package/samples/install.package.yaml <<EOF
 ---
-apiVersion: stacks.crossplane.io/v1alpha1
-kind: ${CLUSTER_STACK}StackInstall
+apiVersion: packages.crossplane.io/v1alpha1
+kind: ${CLUSTER_PACKAGE}PackageInstall
 metadata:
   name: "${KUBEY_PACKAGE_NAME}"
 spec:
   package: "${PACKAGE_IMAGE_NAME}"
 EOF
-  echo 'Created config/package/samples/install.stack.yaml' >&2
+  echo 'Created config/package/samples/install.package.yaml' >&2
 
 }
 
@@ -185,7 +185,7 @@ COPY controllers/ controllers/
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 
 # Use alpine as a minimal base image to package the manager binary
-# Alpine is used instead of distroless because the stack manager expects things like `cp` to exist
+# Alpine is used instead of distroless because the package manager expects things like `cp` to exist
 FROM alpine:3.7
 WORKDIR /
 COPY package /
@@ -316,13 +316,13 @@ package-local-build: bundle
 local-build: package-local-build docker-build docker-local-push
 .PHONY: local-build
 
-# Install a locally-built package using the sample stack installation CR
+# Install a locally-built package using the sample package installation CR
 package-install:
-	kubectl apply -f $(CONFIG_SAMPLES_DIR)/local.install.stack.yaml
+	kubectl apply -f $(CONFIG_SAMPLES_DIR)/local.install.package.yaml
 .PHONY: package-install
 
 package-uninstall:
-	kubectl delete -f $(CONFIG_SAMPLES_DIR)/local.install.stack.yaml
+	kubectl delete -f $(CONFIG_SAMPLES_DIR)/local.install.package.yaml
 .PHONY: package-uninstall
 
 # Build the docker image

--- a/bin/kubectl-crossplane-package-install
+++ b/bin/kubectl-crossplane-package-install
@@ -20,7 +20,7 @@ function usage {
   echo 'For more advanced usage, see the lower-level `kubectl crossplane package generate-install` command.' >&2
 }
 
-CLUSTER_STACK=""
+CLUSTER_PACKAGE=""
 CLUSTER_OPT=""
 NAMESPACE_OPT=""
 IMAGE_PULL_SECRET=""
@@ -32,7 +32,7 @@ while [[ $# -gt 0 ]]; do
 
   case $opt in
     -c|--cluster)
-      CLUSTER_STACK="cluster"
+      CLUSTER_PACKAGE="cluster"
       CLUSTER_OPT="$opt"
       shift
       ;;
@@ -95,7 +95,7 @@ KUBEY_PACKAGE_IMAGE_NAME=$( echo "${PACKAGE_IMAGE_NAME}" | tr '/' '-' | sed 's/:
 PACKAGE_NAME="${2:-${KUBEY_PACKAGE_IMAGE_NAME}}"
 
 kubectl crossplane package generate-install ${CLUSTER_OPT} ${IMAGE_PULL_SECRET_OPT} "$@" | kubectl apply ${NAMESPACE_OPT} -f -
-# Printing out the stack install object from the cluster may be useful
+# Printing out the package install object from the cluster may be useful
 # for whoever ran this command, and there's no other output anyway, so
 # we might as well.
-kubectl get ${NAMESPACE_OPT} -o yaml "${CLUSTER_STACK}"stackinstall "${PACKAGE_NAME}"
+kubectl get ${NAMESPACE_OPT} -o yaml "${CLUSTER_PACKAGE}"packageinstall "${PACKAGE_NAME}"

--- a/bin/kubectl-crossplane-package-list
+++ b/bin/kubectl-crossplane-package-list
@@ -4,7 +4,7 @@ set -e
 
 function usage {
   # The reason for putting package name before package image source is it seems like package name
-  # would be overridden more often than stack image source, but I kept going back and
+  # would be overridden more often than package image source, but I kept going back and
   # forth on that originally. Overriding the source is very useful when developing a
   # package locally, for example.
   echo "Usage: kubectl crossplane package list [-h|--help] [OPTIONS]" >&2
@@ -32,4 +32,4 @@ if [[ $# -gt 0 ]]; then
   ALL_NAMESPACES=
 fi
 
-kubectl get stackinstalls.stacks.crossplane.io,clusterstackinstalls.stacks.crossplane.io ${ALL_NAMESPACES} "${@}"
+kubectl get packageinstalls.packages.crossplane.io,clusterpackageinstalls.packages.crossplane.io ${ALL_NAMESPACES} "${@}"

--- a/bin/kubectl-crossplane-package-uninstall
+++ b/bin/kubectl-crossplane-package-uninstall
@@ -28,13 +28,13 @@ fi
 
 CLUSTER_OPT=${1}
 if [ "${CLUSTER_OPT}" == "-c" -o "${CLUSTER_OPT}" == "--cluster" ]; then
-  CLUSTER_STACK="cluster"
+  CLUSTER_PACKAGE="cluster"
   shift
 else
-  CLUSTER_STACK=""
+  CLUSTER_PACKAGE=""
 fi
 
 PACKAGE_NAME="${1}"
 shift
 
-kubectl delete "${CLUSTER_STACK}"stackinstall "${PACKAGE_NAME}" "$@"
+kubectl delete "${CLUSTER_PACKAGE}"packageinstall "${PACKAGE_NAME}" "$@"

--- a/pkg/crossplane/application.go
+++ b/pkg/crossplane/application.go
@@ -81,7 +81,7 @@ func (o *Application) GetRelated(filterByLabel func(metav1.GroupVersionKind, str
 			Kind: k,
 		}, o.instance.GetNamespace(), getNestedLabelSelector(obj, fieldsAppResourceMatchLabels...))
 		// Ignore NoMatchError since all resources/kinds may not be available on the API,
-		// e.g. ignore if AWS stack is not installed when working GCP only.
+		// e.g. ignore if AWS package is not installed when working GCP only.
 		if err != nil && !meta.IsNoMatchError(err) {
 			return related, err
 		}


### PR DESCRIPTION
This updates all crossplane-cli commands that deal with Stack/StackInstall/ClusterStackInstall to instead use their new Package naming.

Depends on https://github.com/crossplane/crossplane/pull/1501

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>