### PR TITLE
Simpler installation and some emojis in output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,8 @@ clean:
 .PHONY: clean
 
 install:
-	ln -si $(abspath bin/kubectl-crossplane*) $(INSTALL_DIR)/
+	cp $(abspath bin/kubectl-crossplane*) $(INSTALL_DIR)/
 .PHONY: install
-
-uninstall:
-	rm $(INSTALL_DIR)/kubectl-crossplane*
-.PHONY: uninstall
 
 integration-test:
 	mkdir -p test

--- a/README.md
+++ b/README.md
@@ -12,21 +12,8 @@ The behavior is customizable via environment variables:
 
 ```
 RELEASE=v0.2.0
-PREFIX=${HOME}
-curl -sL https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bootstrap.sh | env PREFIX=${PREFIX} RELEASE=${RELEASE} bash
+curl -sL https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bootstrap.sh | RELEASE=${RELEASE} bash
 ```
-
-You can get the latest, bleeding-edge versions of the `package` commands
-by setting `RELEASE` as `master`.
-
-```
-RELEASE=master && curl -sL https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bootstrap.sh | RELEASE=${RELEASE} bash
-```
-
-But please note, the `trace` command will not be installed in this case,
-because it's a built binary and isn't set up to be easily downloaded
-from `master`. To use `trace` from `master`, we recommend building and
-installing from source.
 
 ### Installing from source
 
@@ -45,21 +32,6 @@ everything with:
 
 ```
 rm /usr/local/bin/kubectl-crossplane*
-```
-
-Or, if you customized the installation prefix:
-
-```
-PREFIX=/thing
-rm "${PREFIX}"/bin/kubectl-crossplane*
-```
-
-### Uninstalling from source
-
-If you have the source repository checked out:
-
-```
-make uninstall
 ```
 
 ## Release

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Here's the one-liner to install latest released version:
 curl -sL https://raw.githubusercontent.com/crossplane/crossplane-cli/master/bootstrap.sh | bash
 ```
 
-The behavior is customizable via environment variables:
+You can install a specific release with the following command:
 
 ```
 RELEASE=v0.2.0

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,6 +10,11 @@ if [[ "${OSTYPE}" == "darwin"* ]]; then
   PLATFORM="darwin"
 fi
 
-curl -sL https://github.com/crossplane/crossplane-cli/releases/download/"${RELEASE}"/crossplane-cli_"${RELEASE}"_"${PLATFORM}"_amd64.tar.gz | tar -xz -v --strip 1 -C /usr/local/bin
+curl -sL https://github.com/crossplane/crossplane-cli/releases/download/"${RELEASE}"/crossplane-cli_"${RELEASE}"_"${PLATFORM}"_amd64.tar.gz \
+  | tar -xz -v --strip 1 -C /usr/local/bin 2>&1 \
+  | sed 's/x /✓ /g'
 
 chmod +x /usr/local/bin/kubectl-crossplane*
+
+printf "👍 Crossplane CLI installed successfully!"
+printf "\n\nHave a nice day! 👋\n"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
-
 set -e
-
-if [[ -z "${PREFIX}" ]]; then
-  PREFIX=/usr/local
-fi
 
 if [[ -z "${RELEASE}" ]]; then
   RELEASE=$(curl -L -s -H 'Accept: application/json' https://github.com/crossplane/crossplane-cli/releases/latest | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
@@ -15,26 +10,6 @@ if [[ "${OSTYPE}" == "darwin"* ]]; then
   PLATFORM="darwin"
 fi
 
-set -x
+curl -sL https://github.com/crossplane/crossplane-cli/releases/download/"${RELEASE}"/crossplane-cli_"${RELEASE}"_"${PLATFORM}"_amd64.tar.gz | tar -xz -v --strip 1 -C /usr/local/bin
 
-if [[ "${RELEASE}" == "master" || "${RELEASE}" == release-0.1 ]]; then
-  set +x
-  echo "NOTICE: the trace and pack commands are not available from master. RELEASE must be set to a released version (such as v0.2.0). See https://github.com/crossplane/crossplane-cli/releases for the full list of releases." >&2
-  set -x
-  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane >/dev/null
-  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-krew-wrapper https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-krew-wrapper >/dev/null
-  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package >/dev/null
-  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-build https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-build >/dev/null
-  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-init https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-init >/dev/null
-  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-publish https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-publish >/dev/null
-  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-install https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-install >/dev/null
-  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-uninstall https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-uninstall >/dev/null
-  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-generate_install https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-generate_install >/dev/null
-  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-package-list https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-package-list >/dev/null
-  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-registry https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-registry >/dev/null
-  curl -sL -o "${PREFIX}"/bin/kubectl-crossplane-registry-login https://raw.githubusercontent.com/crossplane/crossplane-cli/"${RELEASE}"/bin/kubectl-crossplane-registry-login >/dev/null
-else
-  curl -sL https://github.com/crossplane/crossplane-cli/releases/download/"${RELEASE}"/crossplane-cli_"${RELEASE}"_"${PLATFORM}"_amd64.tar.gz | tar -xz -v --strip 1 -C "${PREFIX}"/bin
-fi
-
-chmod +x "${PREFIX}"/bin/kubectl-crossplane*
+chmod +x /usr/local/bin/kubectl-crossplane*


### PR DESCRIPTION
I think that's mostly what people need in 99% of the cases. Main thing removed was using the script to install from master which won't let you have trace and pack because there is no compilation. You can do `make build && make install` to get the master installed, similar to other repositories.

In fact, `bootstrap.sh` got so simple I'm wondering whether we should just put its content in the README. But I liked the emoji output :)

<img width="376" alt="image" src="https://user-images.githubusercontent.com/7584126/82615375-e673af00-9bd2-11ea-932e-d74f691ae90e.png">


Tested on Mac OSX 10.15 with zsh and Ubuntu 20.04 with bash (in Docker container)

